### PR TITLE
Macros

### DIFF
--- a/dotmotif/parsers/v2/__init__.py
+++ b/dotmotif/parsers/v2/__init__.py
@@ -15,18 +15,19 @@ start: comment_or_block+
 
 
 // Contents may be either comment or block.
-comment_or_block: comment
-                | block
+comment_or_block: block
 
 // Comments are signified by a hash followed by anything. Any line that follows
 // a comment hash is thrown away.
-comment         : "#" word*
+
+?comment        : "#" COMMENT
 
 // A block may consist of either an edge ("A -> B") or a "macro", which is
 // essentially an alias capability.
 block           : edge
                 | macro
                 | macro_call
+                | comment
 
 
 
@@ -40,10 +41,13 @@ block           : edge
 macro           : word "(" arglist ")" "{" macro_rules "}"
 
 // A series of arguments to a macro
-?arglist         : word ("," word)*
+?arglist        : word ("," word)*
 
-macro_rules     : edge_macro+
-                | macro_call_re+
+macro_rules     : macro_block+
+
+?macro_block    : edge_macro
+                | macro_call_re
+                | comment
 
 // A "hypothetical" edge that forms a subgraph structure.
 edge_macro      : node_id relation node_id
@@ -63,7 +67,7 @@ macro_call      : word "(" arglist ")"
 edge            : node_id relation node_id
 
 // A Node ID is any contiguous (that is, no whitespace) word.
-?node_id         : word
+?node_id        : word
 
 // A relation is a bipartite: The first character is an indication of whether
 // the relation exists or not. The following characters indicate if a relation
@@ -85,8 +89,11 @@ relation_type   : ">"                               -> rel_def
                 | "[" word "]"                      -> rel_typ
 
 
-?word            : WORD
+?word           : WORD
 
+
+COMMENT         : /\#[^\\n]+/
+%ignore COMMENT
 
 %import common.WORD
 %import common.SIGNED_NUMBER  -> NUMBER
@@ -113,8 +120,8 @@ class DotMotifTransformer(Transformer):
         self._transform_tree(tree)
         return self.G
 
-    def comment(self, words):
-        pass
+    # def comment(self, words):
+    #     pass
 
     def edge(self, tup):
         u, rel, v = tup

--- a/dotmotif/parsers/v2/test_v2_parser.py
+++ b/dotmotif/parsers/v2/test_v2_parser.py
@@ -250,3 +250,61 @@ class TestDotmotif_Parserv2_DM_Macros(unittest.TestCase):
         dm.from_motif(exp)
         edges = list(dm._g.edges(data=True))
         self.assertEqual(len(edges), 10)
+
+    def test_comment_in_macro(self):
+        exp = """\
+        # Outside comment
+        edge(A, B) {
+            # Inside comment
+            A -> B
+        }
+        dualedge(A, B) {
+            # Nested-inside comment
+            edge(A, B)
+            edge(B, A)
+        }
+
+        dualedge(foo, bar)
+        """
+        dm = dotmotif.dotmotif(parser=ParserV2)
+        dm.from_motif(exp)
+        edges = list(dm._g.edges(data=True))
+        self.assertEqual(len(edges), 2)
+
+    def test_combo_macro(self):
+        exp = """\
+        edge(A, B) {
+            A -> B
+        }
+        dualedge(A, B) {
+            # Nested-inside comment!
+            edge(A, B)
+            B -> A
+        }
+
+        dualedge(foo, bar)
+        """
+        dm = dotmotif.dotmotif(parser=ParserV2)
+        dm.from_motif(exp)
+        edges = list(dm._g.edges(data=True))
+        self.assertEqual(len(edges), 2)
+
+    def test_comment_macro_inline(self):
+        exp = """\
+        edge(A, B) {
+            A -> B
+        }
+        dualedge(A, B) {
+            # Nested-inside comment!
+            edge(A, B) # inline comment
+            B -> A
+        }
+
+        dualedge(foo, bar) # inline comment
+        # standalone comment
+        foo -> bar # inline comment
+        """
+        dm = dotmotif.dotmotif(parser=ParserV2)
+        dm.from_motif(exp)
+        edges = list(dm._g.edges(data=True))
+        self.assertEqual(len(edges), 2)


### PR DESCRIPTION
Macros are awesome.

```
in_love_with(A, B) {
    A -> B
}

hates(A, B) {
    A -| B
}

love_triangle(A, B, C) {
    in_love_with(A, B)
    in_love_with(B, C)
    in_love_with(C, A)
}

complex_love_triangles(A, B, C, D) {
    love_triangle(A, B, C)
    love_triangle(C, A, D)
    hates(D, B)
}
```

And then declare it with:
```
complex_love_triangles(john, paul, george, ringo)
complex_love_triangles(stevie, lindsey, christine, mick)
```

Before macros, you had to do this:

```
# Complex love triangle 1:
john -> paul
paul -> george
george -> john
ringo -> george
john -> ringo
ringo -| paul

# Complex love triangle 2:
stevie -> lindsey
lindsey -> christine
christine -> stevie
mick -> christine
stevie -> mick
mick -| lindsey
```

...and if you ever changed the definition of a love triangle... you're SOL.

So... this is better.