### PR TITLE
Dynamic node constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+- **0.6.0**
+    - Features:
+        - Add dynamic node constraints for comparisons at runtime (#74)
+    - DSL:
+        - Add dynamic node constraints with `Node.key [op] Node.key` syntax (#74)
 - **0.5.1**
     - Features:
         - Better search-operator support in `NetworkXExecutor`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
         - Add dynamic node constraints for comparisons at runtime (#74)
     - DSL:
         - Add dynamic node constraints with `Node.key [op] Node.key` syntax (#74)
+    - Executors:
+        - `NetworkXExecutor`: Support dynamic node constraints
+        - `Neo4jExecutor`: Support dynamic node constraints
 - **0.5.1**
     - Features:
         - Better search-operator support in `NetworkXExecutor`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 You can currently write motifs in dotmotif form, which is a DSL that specializes in subgraph query notation.
 
 `threecycle.motif`
+
 ```
 # A excites B
 A -> B [type = "excitatory"]
@@ -50,9 +51,7 @@ You can also pass optional parameters into the constructor for the `dotmotif` ob
 | `enforce_inequality`    | `bool`: `False` | Whether to enforce inequality; in other words, whether two nodes should be permitted to be aliases for the same node. For example, in `A->B->C`; if `A!=C`, then set to `True` |
 | `exclude_automorphisms` | `bool`: `False` | Whether to return only a single example for each detected automorphism. See more in [the documentation](docs/Automorphisms.md)                                                 |
 
-
 For more details on how to write a query, see [Getting Started](docs/start.md).
-
 
 # Citing
 

--- a/dotmotif/__init__.py
+++ b/dotmotif/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Copyright 2018 The Johns Hopkins University Applied Physics Laboratory.
+Copyright 2020 The Johns Hopkins University Applied Physics Laboratory.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ from .validators import DisagreeingEdgesValidator
 from .executors.NetworkXExecutor import NetworkXExecutor
 from .executors.Neo4jExecutor import Neo4jExecutor
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 
 DEFAULT_MOTIF_PARSER = ParserV2
 

--- a/dotmotif/__init__.py
+++ b/dotmotif/__init__.py
@@ -56,6 +56,13 @@ class dotmotif:
             enforce_inequality (bool: False): Whether to enforce inequality; in
                 other words, whether two nodes should be permitted to be aliases
                 for the same node. For example, A>B>C; if A!=C, then set to True
+            pretty_print (bool: True)
+            parser (dotmotif.parsers.Parser: DEFAULT_MOTIF_PARSER): The parser
+                to use to parse the document. Defaults to the v2 parser.
+            exclude_automorphisms (bool: False): Whether to exclude automorphism
+                variants of the motif when rturning results.
+            validators (List[Validator]): A list of dotmotif.Validators to use
+                when verifying the motif for correctness and executability.
 
         """
         self.ignore_direction = kwargs.get("ignore_direction", False)
@@ -77,6 +84,8 @@ class dotmotif:
 
         self._edge_constraints = {}
         self._node_constraints = {}
+        self._dynamic_edge_constraints = {}
+        self._dynamic_node_constraints = {}
         self._automorphisms = []
 
     def from_motif(self, cmd: str):
@@ -90,7 +99,7 @@ class dotmotif:
             A pointer to this dotmotif object, for chaining
 
         """
-        if len(cmd.split("\n")) is 1:
+        if len(cmd.split("\n")) == 1:
             try:
                 cmd = open(cmd, "r").read()
             except FileNotFoundError:
@@ -102,6 +111,8 @@ class dotmotif:
                 self._g,
                 self._edge_constraints,
                 self._node_constraints,
+                self._dynamic_edge_constraints,
+                self._dynamic_node_constraints,
                 self._automorphisms,
             ) = result
         else:
@@ -147,8 +158,14 @@ class dotmotif:
     def list_edge_constraints(self):
         return self._edge_constraints
 
+    def list_dynamic_edge_constraints(self):
+        return self._dynamic_edge_constraints
+
     def list_node_constraints(self):
         return self._node_constraints
+
+    def list_dynamic_node_constraints(self):
+        return self._dynamic_node_constraints
 
     def list_automorphisms(self):
         if not self.exclude_automorphisms:
@@ -197,4 +214,6 @@ class dotmotif:
             f = open(fname, "rb")
         else:
             f = fname
-        return pickle.load(f)
+        result = pickle.load(f)
+        f.close()
+        return result

--- a/dotmotif/executors/Neo4jExecutor.py
+++ b/dotmotif/executors/Neo4jExecutor.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018 The Johns Hopkins University Applied Physics Laboratory.
+Copyright 2020 The Johns Hopkins University Applied Physics Laboratory.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/dotmotif/executors/Neo4jExecutor.py
+++ b/dotmotif/executors/Neo4jExecutor.py
@@ -323,6 +323,21 @@ class Neo4jExecutor(Executor):
                             )
                         )
 
+        # Dynamic node constraints:
+        for n, a in motif.list_dynamic_node_constraints().items():
+            for key, constraints in a.items():
+                for operator, values in constraints.items():
+                    for value in values:
+                        cypher_node_constraints.append(
+                            "{}.{} {} {}.{}".format(
+                                n,
+                                key,
+                                _remapped_operator(operator),
+                                value[0],
+                                value[1],
+                            )
+                        )
+
         conditions.extend([*cypher_node_constraints, *cypher_edge_constraints])
 
         if count_only:
@@ -343,12 +358,16 @@ class Neo4jExecutor(Executor):
 
         if motif.enforce_inequality:
             _nodes = [str(a) for a in motif_graph.nodes()]
-            conditions.extend(sorted(
-                list({
-                    "<>".join(sorted(a))
-                    for a in list(product(_nodes, _nodes))
-                    if a[0] != a[1]
-                }))
+            conditions.extend(
+                sorted(
+                    list(
+                        {
+                            "<>".join(sorted(a))
+                            for a in list(product(_nodes, _nodes))
+                            if a[0] != a[1]
+                        }
+                    )
+                )
             )
 
         automs = motif.list_automorphisms()

--- a/dotmotif/executors/NetworkXExecutor.py
+++ b/dotmotif/executors/NetworkXExecutor.py
@@ -35,7 +35,7 @@ def _edge_satisfies_constraints(edge_attributes: dict, constraints: dict) -> boo
                     # If you encounter a type error, that means the comparison
                     # could not possibly succeed,
                     # # TODO: unless you tried a comparison
-                    # against an undefined value (i.e. VALUE >= undefined)
+                    # against an undefined value (i.e. VALUE != undefined)
                     return False
                 if not operator_success:
                     # Fail fast, if any edge attributes fail the test
@@ -47,11 +47,7 @@ def _node_satisfies_constraints(node_attributes: dict, constraints: dict) -> boo
     """
     Check if a single node satisfies the constraints.
 
-    TODO: This function is distinct from the above because I anticipate that
-    differences will emerge as the implementation matures. But these are
-    currently identical functions otherwise. -- @j6k4m8 Jan 2019
     """
-
     for key, clist in constraints.items():
         for operator, values in clist.items():
             for value in values:

--- a/dotmotif/executors/NetworkXExecutor.py
+++ b/dotmotif/executors/NetworkXExecutor.py
@@ -134,7 +134,6 @@ class NetworkXExecutor(Executor):
                             return False
                         if that_key not in graph.nodes[that_node]:
                             return False
-                        # raise ValueError(graph[this_node][this_key], graph[that_node][that_key])
                         if not _OPERATORS[operator](
                             graph.nodes[this_node][this_key],
                             graph.nodes[that_node][that_key],

--- a/dotmotif/executors/NetworkXExecutor.py
+++ b/dotmotif/executors/NetworkXExecutor.py
@@ -7,30 +7,30 @@ from .Executor import Executor
 if TYPE_CHECKING:
     from .. import dotmotif
 
+_OPERATORS = {
+    "=": lambda x, y: x == y,
+    "==": lambda x, y: x == y,
+    ">=": lambda x, y: x >= y,
+    "<=": lambda x, y: x <= y,
+    "<": lambda x, y: x < y,
+    ">": lambda x, y: x > y,
+    "!=": lambda x, y: x != y,
+    "in": lambda x, y: x in y,
+    "contains": lambda x, y: y in x,
+}
+
 
 def _edge_satisfies_constraints(edge_attributes: dict, constraints: dict) -> bool:
     """
     Check if a single edge satisfies the constraints.
     """
 
-    operators = {
-        "=": lambda x, y: x == y,
-        "==": lambda x, y: x == y,
-        ">=": lambda x, y: x >= y,
-        "<=": lambda x, y: x <= y,
-        "<": lambda x, y: x < y,
-        ">": lambda x, y: x > y,
-        "!=": lambda x, y: x != y,
-        "in": lambda x, y: x in y,
-        "contains": lambda x, y: y in x,
-    }
-
     for key, clist in constraints.items():
         for operator, values in clist.items():
             for value in values:
                 keyvalue_or_none = edge_attributes.get(key, None)
                 try:
-                    operator_success = operators[operator](keyvalue_or_none, value)
+                    operator_success = _OPERATORS[operator](keyvalue_or_none, value)
                 except TypeError:
                     # If you encounter a type error, that means the comparison
                     # could not possibly succeed,
@@ -52,22 +52,10 @@ def _node_satisfies_constraints(node_attributes: dict, constraints: dict) -> boo
     currently identical functions otherwise. -- @j6k4m8 Jan 2019
     """
 
-    operators = {
-        "=": lambda x, y: x == y,
-        "==": lambda x, y: x == y,
-        ">=": lambda x, y: x >= y,
-        "<=": lambda x, y: x <= y,
-        "<": lambda x, y: x < y,
-        ">": lambda x, y: x > y,
-        "!=": lambda x, y: x != y,
-        "in": lambda x, y: x in y,
-        "contains": lambda x, y: y in x,
-    }
-
     for key, clist in constraints.items():
         for operator, values in clist.items():
             for value in values:
-                if not operators[operator](node_attributes.get(key, None), value):
+                if not _OPERATORS[operator](node_attributes.get(key, None), value):
                     # Fail fast, if any node attributes fail the test
                     return False
     return True
@@ -116,6 +104,42 @@ class NetworkXExecutor(Executor):
 
             if not _node_satisfies_constraints(graph.nodes[graph_u], constraint_list):
                 return False
+        return True
+
+    def _validate_dynamic_node_constraints(
+        self, node_isomorphism_map: dict, graph: nx.DiGraph, constraints: dict
+    ) -> bool:
+        """
+        Validate a graph against its dynamic node constraints.
+
+        Dynamic node constraints are constraints that compare two attributes
+        from the graph (rather than one key/val from the graph and a static
+        value that is known a priori).
+
+        Arguments:
+            ...
+
+        Returns:
+            bool
+        """
+        # `constraints` is of the form:
+        # { thisNodeId: { thisKey: { operator: [ ( thatNodeId, thatKey )]}}}
+        for motif_U, constraint_list in constraints.items():
+            this_node = node_isomorphism_map[motif_U]
+            for this_key, operators in constraint_list.items():
+                for operator, that_node_list in operators.items():
+                    for (that_node_V, that_key) in that_node_list:
+                        that_node = node_isomorphism_map[that_node_V]
+                        if this_key not in graph.nodes[this_node]:
+                            return False
+                        if that_key not in graph.nodes[that_node]:
+                            return False
+                        # raise ValueError(graph[this_node][this_key], graph[that_node][that_key])
+                        if not _OPERATORS[operator](
+                            graph.nodes[this_node][this_key],
+                            graph.nodes[that_node][that_key],
+                        ):
+                            return False
         return True
 
     def _validate_edge_constraints(
@@ -215,6 +239,7 @@ class NetworkXExecutor(Executor):
             # motif node names. We need the reverse for pretty much everything
             # we do from here out, so we reverse the pairs.
             {v: k for k, v in mapping.items()}
+            # TODO: Use isomorphism here if requested
             for mapping in gm.subgraph_monomorphisms_iter()
         ]
 
@@ -235,6 +260,9 @@ class NetworkXExecutor(Executor):
                 )
                 and self._validate_node_constraints(
                     r, self.graph, motif.list_node_constraints()
+                )
+                and self._validate_dynamic_node_constraints(
+                    r, self.graph, motif.list_dynamic_node_constraints()
                 )
                 # by default, networkx returns the automorphism that is left-
                 # sorted, so this comparison is _opposite_ the check that we

--- a/dotmotif/executors/__init__.py
+++ b/dotmotif/executors/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2018 The Johns Hopkins University Applied Physics Laboratory.
+Copyright 2020 The Johns Hopkins University Applied Physics Laboratory.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/dotmotif/executors/test_dm_cypher.py
+++ b/dotmotif/executors/test_dm_cypher.py
@@ -199,8 +199,24 @@ class TestDotmotif_nodes_edges_Cypher(unittest.TestCase):
         )
 
 
+class TestDynamicNodeConstraints(unittest.TestCase):
+    def test_dynamic_constraints_in_cypher(self):
+        dm = dotmotif.dotmotif(enforce_inequality=True)
+        dm.from_motif(
+            """
+        A -> B
+        A.radius >= B.radius
+        A.zorf != B.zorf
+        """
+        )
+        self.assertIn(
+            "WHERE A.radius >= B.radius AND A.zorf <> B.zorf",
+            Neo4jExecutor.motif_to_cypher(dm).strip(),
+        )
+
+
 class BugReports(unittest.TestCase):
-    def test_fix_where_clause_github_35(self):
+    def test_fix_where_clause__github_35(self):
         dm = dotmotif.dotmotif(enforce_inequality=True)
         dm.from_motif(
             """
@@ -208,3 +224,4 @@ class BugReports(unittest.TestCase):
         """
         )
         self.assertIn("WHERE", Neo4jExecutor.motif_to_cypher(dm).strip())
+

--- a/dotmotif/executors/test_networkxexecutor.py
+++ b/dotmotif/executors/test_networkxexecutor.py
@@ -486,7 +486,7 @@ class TestDynamicNodeConstraints(unittest.TestCase):
         res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
         self.assertEqual(len(res), 2)
 
-    def test_dynamic_constraints_in_macros(self):
+    def test_dynamic_constraints_in_macros_zero_results(self):
         """
         Test that comparisons may be made between variables, e.g.:
 
@@ -508,4 +508,53 @@ class TestDynamicNodeConstraints(unittest.TestCase):
         """
         dm = dotmotif.dotmotif(parser=ParserV2)
         res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
-        self.assertEqual(len(res), 3)
+        self.assertEqual(len(res), 0)
+
+    def test_dynamic_constraints_in_macros_one_result(self):
+        """
+        Test that comparisons may be made between variables, e.g.:
+
+        A.type != B.type
+
+        """
+        G = nx.DiGraph()
+        G.add_edge("A", "B")
+        G.add_edge("B", "C")
+        G.add_edge("C", "A")
+        G.add_node("A", radius=15)
+        G.add_node("B", radius=10)
+        exp = """\
+        macro(A, B) {
+            A.radius > B.radius
+        }
+        macro(A, B)
+        A -> B
+        """
+        dm = dotmotif.dotmotif(parser=ParserV2)
+        res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
+        self.assertEqual(len(res), 1)
+
+    def test_dynamic_constraints_in_macros_two_result(self):
+        """
+        Test that comparisons may be made between variables, e.g.:
+
+        A.type != B.type
+
+        """
+        G = nx.DiGraph()
+        G.add_edge("A", "B")
+        G.add_edge("B", "C")
+        G.add_edge("C", "A")
+        G.add_node("A", radius=15)
+        G.add_node("B", radius=10)
+        G.add_node("C", radius=10)
+        exp = """\
+        macro(A, B) {
+            A.radius >= B.radius
+        }
+        macro(A, B)
+        A -> B
+        """
+        dm = dotmotif.dotmotif(parser=ParserV2)
+        res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
+        self.assertEqual(len(res), 2)

--- a/dotmotif/executors/test_networkxexecutor.py
+++ b/dotmotif/executors/test_networkxexecutor.py
@@ -421,8 +421,8 @@ class TestSmallMotifs(unittest.TestCase):
         self.assertEqual(len(res), 1)
 
 
-class TestDynammicNodeConstraints(unittest.TestCase):
-    def test_dynamic_constraints(self):
+class TestDynamicNodeConstraints(unittest.TestCase):
+    def test_dynamic_constraints_zero_results(self):
         """
         Test that comparisons may be made between variables, e.g.:
 
@@ -441,7 +441,50 @@ class TestDynammicNodeConstraints(unittest.TestCase):
         """
         dm = dotmotif.dotmotif(parser=ParserV2)
         res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
-        self.assertEqual(len(res), 3)
+        self.assertEqual(len(res), 0)
+
+    def test_dynamic_constraints_one_result(self):
+        """
+        Test that comparisons may be made between variables, e.g.:
+
+        A.type != B.type
+
+        """
+        G = nx.DiGraph()
+        G.add_edge("A", "B")
+        G.add_edge("B", "C")
+        G.add_edge("C", "A")
+        G.add_node("A", radius=25)
+        G.add_node("B", radius=10)
+        exp = """\
+        A -> B
+        A.radius > B.radius
+        """
+        dm = dotmotif.dotmotif(parser=ParserV2)
+        res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
+        self.assertEqual(len(res), 1)
+
+    def test_dynamic_constraints_two_results(self):
+        """
+        Test that comparisons may be made between variables, e.g.:
+
+        A.type != B.type
+
+        """
+        G = nx.DiGraph()
+        G.add_edge("A", "B")
+        G.add_edge("B", "C")
+        G.add_edge("C", "A")
+        G.add_node("A", radius=25)
+        G.add_node("B", radius=10)
+        G.add_node("C", radius=5)
+        exp = """\
+        A -> B
+        A.radius > B.radius
+        """
+        dm = dotmotif.dotmotif(parser=ParserV2)
+        res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
+        self.assertEqual(len(res), 2)
 
     # def test_dynamic_constraints_in_macros(self):
     #     """

--- a/dotmotif/executors/test_networkxexecutor.py
+++ b/dotmotif/executors/test_networkxexecutor.py
@@ -486,26 +486,26 @@ class TestDynamicNodeConstraints(unittest.TestCase):
         res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
         self.assertEqual(len(res), 2)
 
-    # def test_dynamic_constraints_in_macros(self):
-    #     """
-    #     Test that comparisons may be made between variables, e.g.:
+    def test_dynamic_constraints_in_macros(self):
+        """
+        Test that comparisons may be made between variables, e.g.:
 
-    #     A.type != B.type
+        A.type != B.type
 
-    #     """
-    #     G = nx.DiGraph()
-    #     G.add_edge("A", "B")
-    #     G.add_edge("B", "C")
-    #     G.add_edge("C", "A")
-    #     G.add_node("A", radius=5)
-    #     G.add_node("B", radius=10)
-    #     exp = """\
-    #     macro(A, B) {
-    #         A.radius > B.radius
-    #     }
-    #     macro(A, B)
-    #     A -> B
-    #     """
-    #     dm = dotmotif.dotmotif(parser=ParserV2)
-    #     res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
-    #     self.assertEqual(len(res), 3)
+        """
+        G = nx.DiGraph()
+        G.add_edge("A", "B")
+        G.add_edge("B", "C")
+        G.add_edge("C", "A")
+        G.add_node("A", radius=5)
+        G.add_node("B", radius=10)
+        exp = """\
+        macro(A, B) {
+            A.radius > B.radius
+        }
+        macro(A, B)
+        A -> B
+        """
+        dm = dotmotif.dotmotif(parser=ParserV2)
+        res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
+        self.assertEqual(len(res), 3)

--- a/dotmotif/executors/test_networkxexecutor.py
+++ b/dotmotif/executors/test_networkxexecutor.py
@@ -420,6 +420,8 @@ class TestSmallMotifs(unittest.TestCase):
         res = NetworkXExecutor(graph=G).find(motif)
         self.assertEqual(len(res), 1)
 
+
+class TestDynammicNodeConstraints(unittest.TestCase):
     def test_dynamic_constraints(self):
         """
         Test that comparisons may be made between variables, e.g.:
@@ -441,26 +443,26 @@ class TestSmallMotifs(unittest.TestCase):
         res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
         self.assertEqual(len(res), 3)
 
-    def test_dynamic_constraints_in_macros(self):
-        """
-        Test that comparisons may be made between variables, e.g.:
+    # def test_dynamic_constraints_in_macros(self):
+    #     """
+    #     Test that comparisons may be made between variables, e.g.:
 
-        A.type != B.type
+    #     A.type != B.type
 
-        """
-        G = nx.DiGraph()
-        G.add_edge("A", "B")
-        G.add_edge("B", "C")
-        G.add_edge("C", "A")
-        G.add_node("A", radius=5)
-        G.add_node("B", radius=10)
-        exp = """\
-        macro(A, B) {
-            A.radius > B.radius
-        }
-        macro(A, B)
-        A -> B
-        """
-        dm = dotmotif.dotmotif(parser=ParserV2)
-        res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
-        self.assertEqual(len(res), 3)
+    #     """
+    #     G = nx.DiGraph()
+    #     G.add_edge("A", "B")
+    #     G.add_edge("B", "C")
+    #     G.add_edge("C", "A")
+    #     G.add_node("A", radius=5)
+    #     G.add_node("B", radius=10)
+    #     exp = """\
+    #     macro(A, B) {
+    #         A.radius > B.radius
+    #     }
+    #     macro(A, B)
+    #     A -> B
+    #     """
+    #     dm = dotmotif.dotmotif(parser=ParserV2)
+    #     res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
+    #     self.assertEqual(len(res), 3)

--- a/dotmotif/parsers/v2/__init__.py
+++ b/dotmotif/parsers/v2/__init__.py
@@ -24,12 +24,21 @@ class DotMotifTransformer(Transformer):
         self.G = nx.MultiDiGraph()
         self.edge_constraints: dict = {}
         self.node_constraints: dict = {}
+        self.dynamic_edge_constraints: dict = {}
+        self.dynamic_node_constraints: dict = {}
         self.automorphisms: list = []
         super().__init__(*args, **kwargs)
 
     def transform(self, tree):
         self._transform_tree(tree)
-        return self.G, self.edge_constraints, self.node_constraints, self.automorphisms
+        return (
+            self.G,
+            self.edge_constraints,
+            self.node_constraints,
+            self.dynamic_edge_constraints,
+            self.dynamic_node_constraints,
+            self.automorphisms,
+        )
 
     def edge_clauses(self, tup):
         attrs = {}
@@ -47,18 +56,45 @@ class DotMotifTransformer(Transformer):
         return str(key), str(op), val
 
     def node_constraint(self, tup):
-        node_id, key, op, val = tup
-        node_id = str(node_id)
-        key = str(key)
-        op = str(op)
-        val = untype_string(val)
-        if node_id not in self.node_constraints:
-            self.node_constraints[node_id] = {}
-        if key not in self.node_constraints[node_id]:
-            self.node_constraints[node_id][key] = {}
-        if op not in self.node_constraints[node_id][key]:
-            self.node_constraints[node_id][key][op] = []
-        self.node_constraints[node_id][key][op].append(val)
+
+        if len(tup) == 4:
+            # This is of the form "Node.Key [OP] Value"
+            node_id, key, op, val = tup
+            node_id = str(node_id)
+            key = str(key)
+            op = str(op)
+            val = untype_string(val)
+            if node_id not in self.node_constraints:
+                self.node_constraints[node_id] = {}
+            if key not in self.node_constraints[node_id]:
+                self.node_constraints[node_id][key] = {}
+            if op not in self.node_constraints[node_id][key]:
+                self.node_constraints[node_id][key][op] = []
+            self.node_constraints[node_id][key][op].append(val)
+
+        elif len(tup) == 5:
+            # This is of the form "ThisNode.Key [OP] ThatNode.Key"
+            this_node_id, this_key, op, that_node_id, that_key = tup
+
+            this_node_id = str(this_node_id)
+            this_key = str(this_key)
+            that_node_id = str(that_node_id)
+            that_key = str(that_key)
+            op = str(op)
+
+            if this_node_id not in self.dynamic_node_constraints:
+                self.dynamic_node_constraints[this_node_id] = {}
+
+            if this_key not in self.dynamic_node_constraints[this_node_id]:
+                self.dynamic_node_constraints[this_node_id][this_key] = {}
+            if op not in self.dynamic_node_constraints[this_node_id][this_key]:
+                self.dynamic_node_constraints[this_node_id][this_key][op] = []
+            self.dynamic_node_constraints[this_node_id][this_key][op].append(
+                (that_node_id, that_key)
+            )
+
+        else:
+            raise ValueError("Something is wrong with the node comparison ", tup)
 
     def macro_node_constraint(self, tup):
         node_id, key, op, val = tup
@@ -272,7 +308,20 @@ class ParserV2(Parser):
         G = nx.MultiDiGraph()
 
         tree = dm_parser.parse(dm)
-        G, edge_constraints, node_constraints, automorphisms = DotMotifTransformer(
-            validators=self.validators
-        ).transform(tree)
-        return G, edge_constraints, node_constraints, automorphisms
+        (
+            G,
+            edge_constraints,
+            node_constraints,
+            dynamic_edge_constraints,
+            dynamic_node_constraints,
+            automorphisms,
+        ) = DotMotifTransformer(validators=self.validators).transform(tree)
+        return (
+            G,
+            edge_constraints,
+            node_constraints,
+            dynamic_edge_constraints,
+            dynamic_node_constraints,
+            automorphisms,
+        )
+

--- a/dotmotif/parsers/v2/grammar.lark
+++ b/dotmotif/parsers/v2/grammar.lark
@@ -87,10 +87,11 @@ edge_clause     : key op value
 
 
 // Node constraints:
-node_constraint : node_id "." key op value_or_quoted_value
-                | node_id "." key op node_id "." key
+node_constraint         : node_id "." key op value_or_quoted_value
+                        | node_id "." key op node_id "." key
 
-macro_node_constraint : node_id "." key op value_or_quoted_value
+macro_node_constraint   : node_id "." key op value_or_quoted_value
+                        | node_id "." key op node_id "." key
 
 
 // Automorphism notation:

--- a/dotmotif/parsers/v2/grammar.lark
+++ b/dotmotif/parsers/v2/grammar.lark
@@ -88,6 +88,8 @@ edge_clause     : key op value
 
 // Node constraints:
 node_constraint : node_id "." key op value_or_quoted_value
+                | node_id "." key op node_id "." key
+
 macro_node_constraint : node_id "." key op value_or_quoted_value
 
 
@@ -108,7 +110,7 @@ iter_ops        : "contains"                        -> iter_op_contains
                 | "in"                              -> iter_op_in
 
 NAME            : /[a-zA-Z_-]\w*/
-OPERATOR        : /[\=\>\<\!]?[\=]/
+OPERATOR        : /(?:[\!=\>\<][=]?)|(?:\<\>)/
 VAR_SEP         : /[\_\-]/
 COMMENT         : /#[^\n]+/
 DOUBLE_QUOTED_STRING  : /"[^"]*"/

--- a/dotmotif/parsers/v2/grammar.lark
+++ b/dotmotif/parsers/v2/grammar.lark
@@ -80,10 +80,10 @@ relation_type   : ">"                               -> rel_def
                 | "|"                               -> rel_neg
 
 // Edge attributes are separated from the main edge declaration with sqbrackets
-edge_clauses   : edge_clause ("," edge_clause)*
-macro_edge_clauses   : edge_clause ("," edge_clause)*
+edge_clauses            : edge_clause ("," edge_clause)*
+macro_edge_clauses      : edge_clause ("," edge_clause)*
 
-edge_clause     : key op value
+edge_clause             : key op value
 
 
 // Node constraints:

--- a/dotmotif/parsers/v2/test_v2_parser.py
+++ b/dotmotif/parsers/v2/test_v2_parser.py
@@ -428,3 +428,36 @@ class TestDotmotif_Parserv2_DM_NodeAttributes(unittest.TestCase):
         dm.from_motif(exp)
         self.assertEqual(len(dm.list_node_constraints()), 2)
         self.assertEqual(list(dm.list_node_constraints().keys()), ["Aaa", "Ba"])
+
+    def test_dynamic_constraints(self):
+        """
+        Test that comparisons may be made between variables, e.g.:
+
+        A.type != B.type
+
+        """
+        exp = """\
+        A -> B
+        A.radius > B.radius
+        """
+        dm = dotmotif.dotmotif(parser=ParserV2)
+        dm.from_motif(exp)
+        self.assertEqual(len(dm.list_node_constraints()), 1)
+
+    def test_dynamic_constraints_in_macro(self):
+        """
+        Test that comparisons may be made between variables in a macro, e.g.:
+
+        A.type != B.type
+
+        """
+        exp = """\
+        macro(A, B) {
+            A.radius > B.radius
+        }
+        macro(A, B)
+        A -> B
+        """
+        dm = dotmotif.dotmotif(parser=ParserV2)
+        dm.from_motif(exp)
+        self.assertEqual(len(dm.list_node_constraints()), 1)

--- a/dotmotif/parsers/v2/test_v2_parser.py
+++ b/dotmotif/parsers/v2/test_v2_parser.py
@@ -462,4 +462,4 @@ class TestDynamicNodeConstraints(unittest.TestCase):
         """
         dm = dotmotif.dotmotif(parser=ParserV2)
         dm.from_motif(exp)
-        self.assertEqual(len(dm.list_node_constraints()), 1)
+        self.assertEqual(len(dm.list_dynamic_node_constraints()), 1)

--- a/dotmotif/parsers/v2/test_v2_parser.py
+++ b/dotmotif/parsers/v2/test_v2_parser.py
@@ -429,6 +429,8 @@ class TestDotmotif_Parserv2_DM_NodeAttributes(unittest.TestCase):
         self.assertEqual(len(dm.list_node_constraints()), 2)
         self.assertEqual(list(dm.list_node_constraints().keys()), ["Aaa", "Ba"])
 
+
+class TestDynamicNodeConstraints(unittest.TestCase):
     def test_dynamic_constraints(self):
         """
         Test that comparisons may be made between variables, e.g.:
@@ -438,26 +440,26 @@ class TestDotmotif_Parserv2_DM_NodeAttributes(unittest.TestCase):
         """
         exp = """\
         A -> B
-        A.radius > B.radius
+        A.radius < B.radius
         """
         dm = dotmotif.dotmotif(parser=ParserV2)
         dm.from_motif(exp)
-        self.assertEqual(len(dm.list_node_constraints()), 1)
+        self.assertEqual(len(dm.list_dynamic_node_constraints()), 1)
 
-    def test_dynamic_constraints_in_macro(self):
-        """
-        Test that comparisons may be made between variables in a macro, e.g.:
+    # def test_dynamic_constraints_in_macro(self):
+    #     """
+    #     Test that comparisons may be made between variables in a macro, e.g.:
 
-        A.type != B.type
+    #     A.type != B.type
 
-        """
-        exp = """\
-        macro(A, B) {
-            A.radius > B.radius
-        }
-        macro(A, B)
-        A -> B
-        """
-        dm = dotmotif.dotmotif(parser=ParserV2)
-        dm.from_motif(exp)
-        self.assertEqual(len(dm.list_node_constraints()), 1)
+    #     """
+    #     exp = """\
+    #     macro(A, B) {
+    #         A.radius > B.radius
+    #     }
+    #     macro(A, B)
+    #     A -> B
+    #     """
+    #     dm = dotmotif.dotmotif(parser=ParserV2)
+    #     dm.from_motif(exp)
+    #     self.assertEqual(len(dm.list_node_constraints()), 1)

--- a/dotmotif/parsers/v2/test_v2_parser.py
+++ b/dotmotif/parsers/v2/test_v2_parser.py
@@ -446,20 +446,20 @@ class TestDynamicNodeConstraints(unittest.TestCase):
         dm.from_motif(exp)
         self.assertEqual(len(dm.list_dynamic_node_constraints()), 1)
 
-    # def test_dynamic_constraints_in_macro(self):
-    #     """
-    #     Test that comparisons may be made between variables in a macro, e.g.:
+    def test_dynamic_constraints_in_macro(self):
+        """
+        Test that comparisons may be made between variables in a macro, e.g.:
 
-    #     A.type != B.type
+        A.type != B.type
 
-    #     """
-    #     exp = """\
-    #     macro(A, B) {
-    #         A.radius > B.radius
-    #     }
-    #     macro(A, B)
-    #     A -> B
-    #     """
-    #     dm = dotmotif.dotmotif(parser=ParserV2)
-    #     dm.from_motif(exp)
-    #     self.assertEqual(len(dm.list_node_constraints()), 1)
+        """
+        exp = """\
+        macro(A, B) {
+            A.radius > B.radius
+        }
+        macro(A, B)
+        A -> B
+        """
+        dm = dotmotif.dotmotif(parser=ParserV2)
+        dm.from_motif(exp)
+        self.assertEqual(len(dm.list_node_constraints()), 1)

--- a/dotmotif/test_dm_flags.py
+++ b/dotmotif/test_dm_flags.py
@@ -79,7 +79,7 @@ class TestDotmotifFlags(unittest.TestCase):
         dm = dotmotif.dotmotif().from_nx(g)
 
         E = NetworkXExecutor(graph=G)
-        self.assertEquals(len(E.find(dm)), 4)
+        self.assertEqual(len(E.find(dm)), 4)
 
     def test_from_nx_import(self):
         G = nx.Graph()
@@ -91,4 +91,4 @@ class TestDotmotifFlags(unittest.TestCase):
         dm = dotmotif.dotmotif(ignore_direction=True).from_nx(g)
 
         E = NetworkXExecutor(graph=G)
-        self.assertEquals(len(E.find(dm)), 4)
+        self.assertEqual(len(E.find(dm)), 4)

--- a/dotmotif/test_utils.py
+++ b/dotmotif/test_utils.py
@@ -37,3 +37,4 @@ class TestSaveLoad(TestCase):
         self.assertEqual(m.limit, f.limit)
         self.assertEqual(m.enforce_inequality, f.enforce_inequality)
         self.assertEqual(m.pretty_print, f.pretty_print)
+        tf.close()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ python setup.py sdist
 twine upload dist/*
 """
 
-VERSION = "0.5.1"
+VERSION = "0.6.0"
 
 here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, "README.md"), encoding="utf-8") as f:


### PR DESCRIPTION
This pull request adds support for dynamic constraints, or node/edge constraints that reference other nodes. For example,

```rb
A -> B
B.radius > A.radius   # newly available
B.radius < 100
```

### DSL
- [x] Dynamic node constraints
- [x] Node constraints in macros

### NetworkXExecutor

- [x] Node constraints

### Neo4jExecutor

- [x] Node constraints