### PR TITLE
Add Motif class interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
--   **0.7.0**
+-   **0.7.0** (October 14 2020)
     -   Executors:
         -   Add new `NeuPrintExecutor` with motif-search support for neuPrint databases (#76)
-        -   Add new `GrandIsoExecutor` as a fully-python drop-in replacement for `NetworkXExecutor` (#80)
+        -   Add new `GrandIsoExecutor` as a Python-only drop-in replacement for `NetworkXExecutor` (#80). If you're still using `NetworkXExecutor`, you should really switch!
     -   Features:
         -   Improve `utils.draw_motif` rendering style
         -   Improve networkx import for Neo4j databases to use better datatype inference
+        -   New `dotmotif.Motif` class. This is just a naming thing; all your old `dotmotif.dotmotif` code will still work! (#84)
+        -   Short motifs can now be written on a single line, with semicolons to delimit commands (#84)
     -   Bugfixes:
         -   Improve pip-installation process by including EBNF grammar definitions
     -   Documentation:

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ B -> C [type = "inhibitory"]
 ## Ingesting the motif into dotmotif
 
 ```python
-from dotmotif import dotmotif
+import dotmotif
 
-dm = dotmotif().from_motif("threecycle.motif")
+dm = dotmotif.Motif("threecycle.motif")
 ```
 
 ## Inline code in Python
@@ -38,7 +38,7 @@ dm = dotmotif().from_motif("threecycle.motif")
 Alternatively, you can inline your motif in the python code when creating your `dotmotif` object:
 
 ```python
-dm = dotmotif().from_motif("""
+dm = dotmotif.Motif("""
 # A excites B
 A -> B [type = "excitatory"]
 # B inhibits C
@@ -57,7 +57,7 @@ You can also pass optional parameters into the constructor for the `dotmotif` ob
 | `enforce_inequality`    | `bool`: `False` | Whether to enforce inequality; in other words, whether two nodes should be permitted to be aliases for the same node. For example, in `A->B->C`; if `A!=C`, then set to `True` |
 | `exclude_automorphisms` | `bool`: `False` | Whether to return only a single example for each detected automorphism. See more in [the documentation](docs/Automorphisms.md)                                                 |
 
-For more details on how to write a query, see [Getting Started](docs/start.md).
+For more details on how to write a query, see [Getting Started](https://github.com/aplbrain/dotmotif/wiki/Getting-Started).
 
 # Citing
 

--- a/docs/examples/Counting Triangles in MICrONS v185.py
+++ b/docs/examples/Counting Triangles in MICrONS v185.py
@@ -1,19 +1,22 @@
-from dotmotif import dotmotif, GrandIsoExecutor
+from dotmotif import Motif, GrandIsoExecutor
 from dotmotif.ingest import CSVEdgelistConverter
 
 
 graph = CSVEdgelistConverter(
     "https://zenodo.org/record/3710459/files/soma_subgraph_synapses_spines_v185.csv?download=1",
-    "pre_root_id", "post_root_id"
+    "pre_root_id",
+    "post_root_id",
 ).to_graph()
 
 E = GrandIsoExecutor(graph=graph)
 
-motif = dotmotif().from_motif("""
+motif = Motif(
+    """
 A -> B
 B -> C
 C -> A
-""")
+"""
+)
 
 results = E.find(motif)
 

--- a/dotmotif/__init__.py
+++ b/dotmotif/__init__.py
@@ -39,18 +39,20 @@ class MotifError(ValueError):
     pass
 
 
-class dotmotif:
+class Motif:
     """
     Container class for dotmotif operations.
 
     See __init__ documentation for more details.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, input_motif: str = None, **kwargs):
         """
         Create a new dotmotif object.
 
         Arguments:
+            input_motif (str: None): Optionally, a DotMotif DSL defined motif,
+                or a path to a .motif file that contains a motif.
             ignore_direction (bool: False): Whether to disregard direction when
                 generating the database query
             limit (int: None): A limit (if any) to impose on the query results
@@ -80,6 +82,9 @@ class dotmotif:
         self._dynamic_edge_constraints = {}
         self._dynamic_node_constraints = {}
         self._automorphisms = []
+
+        if input_motif:
+            self.from_motif(input_motif)
 
     def from_motif(self, cmd: str):
         """
@@ -210,3 +215,6 @@ class dotmotif:
         result = pickle.load(f)
         f.close()
         return result
+
+
+dotmotif = Motif

--- a/dotmotif/parsers/v2/grammar.lark
+++ b/dotmotif/parsers/v2/grammar.lark
@@ -4,6 +4,7 @@ start: comment_or_block+
 
 // Contents may be either comment or block.
 comment_or_block: block
+                | block ";"
 
 // Comments are signified by a hash followed by anything. Any line that follows
 // a comment hash is thrown away.


### PR DESCRIPTION
a slightly more elegant way of doing the same things:

#### old

```python
from dotmotif import dotmotif

dotmotif(...).from_motif("A -> B")
```

#### new

```python
import dotmotif

dotmotif.Motif("A -> B", ...)
```

Fixes #83.