### PR TITLE
Add !contains and !in constraint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+-   **0.7.1**
+    -   Features:
+        -   Add `!contains` and `!in` attribute constraints to the parser.
 -   **0.7.0** (October 14 2020)
     -   Executors:
         -   Add new `NeuPrintExecutor` with motif-search support for neuPrint databases (#76)

--- a/dotmotif/executors/NetworkXExecutor.py
+++ b/dotmotif/executors/NetworkXExecutor.py
@@ -17,6 +17,8 @@ _OPERATORS = {
     "!=": lambda x, y: x != y,
     "in": lambda x, y: x in y,
     "contains": lambda x, y: y in x,
+    "!in": lambda x, y: x not in y,
+    "!contains": lambda x, y: y not in x,
 }
 
 

--- a/dotmotif/executors/test_networkxexecutor.py
+++ b/dotmotif/executors/test_networkxexecutor.py
@@ -558,3 +558,38 @@ class TestDynamicNodeConstraints(unittest.TestCase):
         dm = dotmotif.dotmotif(parser=ParserV2)
         res = NetworkXExecutor(graph=G).find(dm.from_motif(exp))
         self.assertEqual(len(res), 2)
+
+
+class TestNotInAndNotContains(unittest.TestCase):
+    def test_not_contains(self):
+        m = dotmotif.Motif(
+            """
+        A -> B
+        A.name !contains "foo"
+        """
+        )
+
+        host = nx.DiGraph()
+        host.add_edge("A", "B")
+        host.add_edge("B", "A")
+        host.add_node("A", name="the foobar")
+        host.add_node("B", name="Barbaz")
+
+        res = NetworkXExecutor(graph=host).find(m)
+        self.assertEqual(len(res), 1)
+
+    def test_not_in(self):
+        m = dotmotif.Motif(
+            """
+        A -> B
+        A.name !in "foo"
+        """
+        )
+
+        host = nx.DiGraph()
+        host.add_edge("A", "B")
+        host.add_node("A", name="the foobar")
+        host.add_node("B", name="Barbaz")
+
+        res = NetworkXExecutor(graph=host).find(m)
+        self.assertEqual(len(res), 1)

--- a/dotmotif/parsers/v2/__init__.py
+++ b/dotmotif/parsers/v2/__init__.py
@@ -194,6 +194,12 @@ class DotMotifTransformer(Transformer):
     def iter_op_in(self, _):
         return "in"
 
+    def iter_op_not_contains(self, _):
+        return "!contains"
+
+    def iter_op_not_in(self, _):
+        return "!in"
+
     # Macros
     def macro(self, arg):
         name, args, rules = arg

--- a/dotmotif/parsers/v2/grammar.lark
+++ b/dotmotif/parsers/v2/grammar.lark
@@ -110,6 +110,8 @@ variable       : NAME
 
 iter_ops        : "contains"                        -> iter_op_contains
                 | "in"                              -> iter_op_in
+                | "!contains"                       -> iter_op_not_contains
+                | "!in"                             -> iter_op_not_in
 
 NAME            : /[a-zA-Z_-]\w*/
 OPERATOR        : /(?:[\!=\>\<][=]?)|(?:\<\>)/


### PR DESCRIPTION
Fixes #87.

This PR adds support for the negated `in` and `contains` operators for assigning attribute constraints by prepending them with the `!` not operator:

```C
A -> B

A.name !contains "blah"
```