### PR TITLE
Fix issue where grammar file was excluded from pip installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 -   **0.7.1**
     -   Features:
-        -   Add `!contains` and `!in` attribute constraints to the parser.
+        -   Add `!contains` and `!in` attribute constraints to the parser. (#88)
+    -   Bugfixes:
+        -   Fix issue where lark grammar file is excluded from pip-based installs (#89)
 -   **0.7.0** (October 14 2020)
     -   Executors:
         -   Add new `NeuPrintExecutor` with motif-search support for neuPrint databases (#76)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ python setup.py sdist
 twine upload dist/*
 """
 
-VERSION = "0.7.0"
+VERSION = "0.7.1"
 
 here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, "README.md"), encoding="utf-8") as f:
@@ -42,4 +42,5 @@ setup(
         "neuprint-python",
         "grandiso",
     ],
+    include_package_data=True,
 )


### PR DESCRIPTION
Fixes #86.

Resolves the installation error encountered in #86. Thank you to @lix2k3 for reporting :)