### PR TITLE
Upgrade grandiso to use generator API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+-   **0.9.1**
+    -   Features:
+        -   `GrandIsoExecutor`: Adds support for the `grandiso.find_motifs_iter` generator API in grandiso v1.2.0; this reduces the runtime of queries with nonzero `limit` #102
 -   **0.9.0** (March 23 2021)
     -   Features:
         -   `Neo4jExecutor#create_index`. This function call adds an index to the database on the node attribute specified, in order to improve query performance (#95)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ py2neo
 dask[dataframe]
 tamarind>=0.2.0
 neuprint-python
-grandiso>=1.1.0
+grandiso>=1.2.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ python setup.py sdist
 twine upload dist/*
 """
 
-VERSION = "0.9.0"
+VERSION = "0.9.1"
 
 here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, "README.md"), encoding="utf-8") as f:
@@ -25,7 +25,7 @@ setup(
     description=("Find graph motifs using simple, intuitive notation"),
     long_description=long_description,
     long_description_content_type="text/markdown",
-    license="ISC",
+    license="Apache 2.0",
     keywords=["graph", "motif"],
     url="https://github.com/aplbrain/dotmotif/tarball/" + VERSION,
     packages=find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
@@ -40,7 +40,7 @@ setup(
         "dask[dataframe]",
         "tamarind>=0.1.5",
         "neuprint-python",
-        "grandiso",
+        "grandiso>=1.2.0",
     ],
     include_package_data=True,
 )


### PR DESCRIPTION
Switches the GrandIso executor to use `grandiso.find_motifs_iter` from ^1.2.0.

This will dramatically improve worst-case performance by eliminating all search overhead past the requested count `limit`.

No API changes. Resolves #97 