### PR TITLE
Add edge aliasing and edge constraints

### DIFF
--- a/dotmotif/__init__.py
+++ b/dotmotif/__init__.py
@@ -29,13 +29,7 @@ from .validators import DisagreeingEdgesValidator
 from .executors.NetworkXExecutor import NetworkXExecutor
 from .executors.GrandIsoExecutor import GrandIsoExecutor
 
-try:
-    # For backwards compatibility:
-    from .executors.Neo4jExecutor import Neo4jExecutor
-except ImportError:
-    pass
-
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 DEFAULT_MOTIF_PARSER = ParserV2
 

--- a/dotmotif/executors/GrandIsoExecutor.py
+++ b/dotmotif/executors/GrandIsoExecutor.py
@@ -93,14 +93,15 @@ class GrandIsoExecutor(NetworkXExecutor):
                 else self._validate_multigraph_any_edge_constraints
             )
         )
+        _edge_dynamic_constraint_validator = self._validate_dynamic_edge_constraints
 
         results = []
         for r in graph_matches:
             if _doesnt_have_any_of_motifs_negative_edges(r) and (
                 _edge_constraint_validator(r, self.graph, motif.list_edge_constraints())
-                # and self._validate_node_constraints(
-                #     r, self.graph, motif.list_node_constraints()
-                # )
+                and _edge_dynamic_constraint_validator(
+                    r, self.graph, motif.list_dynamic_edge_constraints()
+                )
                 and self._validate_dynamic_node_constraints(
                     r, self.graph, motif.list_dynamic_node_constraints()
                 )

--- a/dotmotif/executors/test_dm_cypher.py
+++ b/dotmotif/executors/test_dm_cypher.py
@@ -215,6 +215,22 @@ class TestDynamicNodeConstraints(unittest.TestCase):
         )
 
 
+class TestDynamicEdgeConstraints(unittest.TestCase):
+    def test_dynamic_constraints_in_cypher(self):
+        dm = dotmotif.Motif(enforce_inequality=True)
+        dm.from_motif(
+            """
+        A -> B as AB
+        A -> C as AC
+        AB.weight >= AC.weight
+        """
+        )
+        self.assertIn(
+            """WHERE A_B["weight"] >= A_C["weight"]""",
+            Neo4jExecutor.motif_to_cypher(dm).strip(),
+        )
+
+
 class BugReports(unittest.TestCase):
     def test_fix_where_clause__github_35(self):
         dm = dotmotif.Motif(enforce_inequality=True)

--- a/dotmotif/executors/test_grandisoexecutor.py
+++ b/dotmotif/executors/test_grandisoexecutor.py
@@ -367,3 +367,63 @@ class TestDynamicNodeConstraints(unittest.TestCase):
         dm = dotmotif.Motif(parser=ParserV2)
         res = GrandIsoExecutor(graph=G).find(dm.from_motif(exp))
         self.assertEqual(len(res), 2)
+
+
+class TestNamedEdgeConstraints(unittest.TestCase):
+    def test_equality_edge_attributes(self):
+        host = nx.DiGraph()
+        host.add_edge("A", "B", weight=1)
+        host.add_edge("A", "C", weight=1)
+
+        exp = """\
+        A -> B as A_B
+        A -> C as A_C
+        A_B.weight == A_C.weight
+        """
+
+        dm = dotmotif.Motif(parser=ParserV2)
+        res = GrandIsoExecutor(graph=host).find(dm.from_motif(exp))
+        self.assertEqual(len(res), 2)
+
+        host = nx.DiGraph()
+        host.add_edge("A", "B", weight=1)
+        host.add_edge("A", "C", weight=2)
+
+        exp = """\
+        A -> B as A_B
+        A -> C as A_C
+        A_B.weight == A_C.weight
+        """
+
+        dm = dotmotif.Motif(parser=ParserV2)
+        res = GrandIsoExecutor(graph=host).find(dm.from_motif(exp))
+        self.assertEqual(len(res), 0)
+
+    def test_inequality_edge_attributes(self):
+        host = nx.DiGraph()
+        host.add_edge("A", "B", weight=1)
+        host.add_edge("A", "C", weight=1)
+
+        exp = """\
+        A -> B as A_B
+        A -> C as A_C
+        A_B.weight != A_C.weight
+        """
+
+        dm = dotmotif.Motif(parser=ParserV2)
+        res = GrandIsoExecutor(graph=host).find(dm.from_motif(exp))
+        self.assertEqual(len(res), 0)
+
+        host = nx.DiGraph()
+        host.add_edge("A", "B", weight=1)
+        host.add_edge("A", "C", weight=2)
+
+        exp = """\
+        A -> B as A_B
+        A -> C as A_C
+        A_B.weight != A_C.weight
+        """
+
+        dm = dotmotif.Motif(parser=ParserV2)
+        res = GrandIsoExecutor(graph=host).find(dm.from_motif(exp))
+        self.assertEqual(len(res), 2)

--- a/dotmotif/executors/test_grandisoexecutor.py
+++ b/dotmotif/executors/test_grandisoexecutor.py
@@ -427,3 +427,49 @@ class TestNamedEdgeConstraints(unittest.TestCase):
         dm = dotmotif.Motif(parser=ParserV2)
         res = GrandIsoExecutor(graph=host).find(dm.from_motif(exp))
         self.assertEqual(len(res), 2)
+
+    def test_aliased_edge_comparison(self):
+        exp = """\
+        A -> B as ab
+        A -> C as ac
+        ab.type = ac.type
+        """
+        dm = dotmotif.Motif(exp)
+        host = nx.DiGraph()
+        host.add_edge("A", "B", type="a")
+        host.add_edge("A", "C", type="b")
+        host.add_edge("A", "D", type="b")
+        res = GrandIsoExecutor(graph=host).find(dm)
+        self.assertEqual(len(res), 2)
+
+    def test_aliased_edge_comparisons(self):
+        exp = """\
+        A -> B as ab
+        B -> C as bc
+        C -> D as cd
+
+        ab.length >= bc.length
+        bc.length >= cd.length
+        """
+        dm = dotmotif.Motif(exp)
+        host = nx.DiGraph()
+        host.add_edge("A", "B", length=1)
+        host.add_edge("B", "C", length=1)
+        host.add_edge("C", "D", length=1)
+        res = GrandIsoExecutor(graph=host).find(dm)
+        self.assertEqual(len(res), 1)
+
+    def test_aliased_edge_comparisons_with_different_edge_attributes(self):
+        exp = """\
+        B -> C as bc
+        C -> D as cd
+
+        bc.length > cd.weight
+        """
+        dm = dotmotif.Motif(exp)
+        host = nx.DiGraph()
+        host.add_edge("A", "C", length=2)
+        host.add_edge("B", "C", length=2)
+        host.add_edge("C", "D", length=1, weight=1)
+        res = GrandIsoExecutor(graph=host).find(dm)
+        self.assertEqual(len(res), 2)

--- a/dotmotif/executors/test_grandisoexecutor.py
+++ b/dotmotif/executors/test_grandisoexecutor.py
@@ -473,3 +473,32 @@ class TestNamedEdgeConstraints(unittest.TestCase):
         host.add_edge("C", "D", length=1, weight=1)
         res = GrandIsoExecutor(graph=host).find(dm)
         self.assertEqual(len(res), 2)
+
+
+# class TestEdgeConstraintsInMacros(unittest.TestCase):
+#     def test_edge_comparison_in_macro(self):
+#         host = nx.DiGraph()
+#         host.add_edge("A", "B", foo=1)
+#         host.add_edge("A", "C", foo=2)
+#         host.add_edge("B", "C", foo=0.5)
+#         host.add_edge("C", "D", foo=0.25)
+#         host.add_edge("D", "C", foo=1)
+#         host.add_edge("C", "B", foo=2)
+#         host.add_edge("B", "A", foo=2)
+#         E = GrandIsoExecutor(graph=host)
+
+#         M = Motif(
+#             """
+
+#         descending(a, b, c) {
+#             a -> b as Edge1
+#             b -> c as Edge2
+#             Edge1.foo > Edge2.foo
+#         }
+
+#         descending(a, b, c)
+#         descending(b, c, d)
+
+#         """
+#         )
+#         assert E.count(M) == 1

--- a/dotmotif/parsers/v2/__init__.py
+++ b/dotmotif/parsers/v2/__init__.py
@@ -86,7 +86,7 @@ class DotMotifTransformer(Transformer):
                         self.dynamic_node_constraints[entity_id][key][op].extend(values)
 
             elif entity_id in self.named_edges:
-                # This is a named edge:
+                # This is a named edge dynamic correspondence:
                 (u, v, attrs) = self.named_edges[entity_id]
                 if (u, v) not in self.dynamic_edge_constraints:
                     self.dynamic_edge_constraints[(u, v)] = {}
@@ -94,9 +94,14 @@ class DotMotifTransformer(Transformer):
                     if key not in self.dynamic_edge_constraints[(u, v)]:
                         self.dynamic_edge_constraints[(u, v)][key] = {}
                     for op, values in ops.items():
-                        if op not in self.dynamic_edge_constraints[(u, v)][key]:
-                            self.dynamic_edge_constraints[(u, v)][key][op] = []
-                        self.dynamic_edge_constraints[(u, v)][key][op].extend(values)
+                        for value in values:
+                            that_edge, that_attr = value
+                            tu, tv, _ = self.named_edges[that_edge]
+                            if op not in self.dynamic_edge_constraints[(u, v)][key]:
+                                self.dynamic_edge_constraints[(u, v)][key][op] = []
+                            self.dynamic_edge_constraints[(u, v)][key][op].extend(
+                                (tu, tv, that_attr)
+                            )
             else:
                 raise KeyError(
                     f"Entity {entity_id} is neither a node nor a named edge in this motif."

--- a/dotmotif/parsers/v2/__init__.py
+++ b/dotmotif/parsers/v2/__init__.py
@@ -13,6 +13,17 @@ from ...validators import Validator
 dm_parser = Lark(open(os.path.join(os.path.dirname(__file__), "grammar.lark"), "r"))
 
 
+def _unquote_string(s):
+    """
+    Remove quotes from a string.
+    """
+    if s[0] == '"' and s[-1] == '"':
+        return s[1:-1]
+    if s[0] == "'" and s[-1] == "'":
+        return s[1:-1]
+    return s
+
+
 class DotMotifTransformer(Transformer):
     """
     This transformer converts a parsed Lark tree into a networkx.MultiGraph.
@@ -132,14 +143,12 @@ class DotMotifTransformer(Transformer):
         return str(key), str(op), val
 
     def node_constraint(self, tup):
-        # TODO: Should rename this from `node_constraint` to accomodate
-        # the case where this refers to a constraint on a named edge.
-
         if len(tup) == 4:
             # This is of the form "Node.Key [OP] Value"
             node_id, key, op, val = tup
             node_id = str(node_id)
             key = str(key)
+            key = _unquote_string(key)
             op = str(op)
             val = untype_string(val)
 
@@ -157,8 +166,10 @@ class DotMotifTransformer(Transformer):
 
             this_node_id = str(this_node_id)
             this_key = str(this_key)
+            this_key = _unquote_string(this_key)
             that_node_id = str(that_node_id)
             that_key = str(that_key)
+            that_key = _unquote_string(that_key)
             op = str(op)
 
             if this_node_id not in self._dynamic_constraints:

--- a/dotmotif/parsers/v2/__init__.py
+++ b/dotmotif/parsers/v2/__init__.py
@@ -26,6 +26,7 @@ class DotMotifTransformer(Transformer):
         self.node_constraints: dict = {}
         self.dynamic_edge_constraints: dict = {}
         self.dynamic_node_constraints: dict = {}
+        self.named_edges: dict = {}
         self.automorphisms: list = []
         super().__init__(*args, **kwargs)
 
@@ -159,6 +160,18 @@ class DotMotifTransformer(Transformer):
         self.G.add_edge(
             u, v, exists=rel["exists"], action=rel["type"], constraints=attrs
         )
+
+    def named_edge(self, tup):
+        if len(tup) == 4:
+            u, rel, v, name = tup
+            attrs = {}
+        elif len(tup) == 5:
+            u, rel, v, attrs, name = tup
+        else:
+            raise ValueError("Something is wrong with the named edge", tup)
+
+        self.named_edges[name] = (u, v, attrs)
+        self.edge(tup[:-1])
 
     def automorphism_notation(self, tup):
         self.automorphisms.append(tup)
@@ -330,8 +343,7 @@ class ParserV2(Parser):
             self.validators = validators
 
     def parse(self, dm: str) -> nx.MultiDiGraph:
-        """
-        """
+        """ """
         G = nx.MultiDiGraph()
 
         tree = dm_parser.parse(dm)
@@ -351,4 +363,3 @@ class ParserV2(Parser):
             dynamic_node_constraints,
             automorphisms,
         )
-

--- a/dotmotif/parsers/v2/__init__.py
+++ b/dotmotif/parsers/v2/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 from typing import List
+import os
 from lark import Lark, Transformer
 import networkx as nx
-import os
 
 from ...utils import untype_string
 from .. import Parser

--- a/dotmotif/parsers/v2/__init__.py
+++ b/dotmotif/parsers/v2/__init__.py
@@ -66,7 +66,7 @@ class DotMotifTransformer(Transformer):
                             self.edge_constraints[(u, v)][key][op] = []
                         self.edge_constraints[(u, v)][key][op].extend(values)
             else:
-                raise ValueError(
+                raise KeyError(
                     f"Entity {entity_id} is neither a node nor a named edge in this motif."
                 )
 
@@ -98,7 +98,7 @@ class DotMotifTransformer(Transformer):
                             self.dynamic_edge_constraints[(u, v)][key][op] = []
                         self.dynamic_edge_constraints[(u, v)][key][op].extend(values)
             else:
-                raise ValueError(
+                raise KeyError(
                     f"Entity {entity_id} is neither a node nor a named edge in this motif."
                 )
 
@@ -214,6 +214,8 @@ class DotMotifTransformer(Transformer):
             attrs = {}
         elif len(tup) == 4:
             u, rel, v, attrs = tup
+        else:
+            raise ValueError(f"Invalid edge definition {tup}")
         u = str(u)
         v = str(v)
         for val in self.validators:
@@ -300,8 +302,8 @@ class DotMotifTransformer(Transformer):
             attrs = {}
         elif len(tup) == 4:
             u, rel, v, attrs = tup
-        # else:
-        #     print(tup, len(tup))
+        else:
+            raise ValueError(f"Invalid edge definition {tup} in macro.")
         u = str(u)
         v = str(v)
         return (str(u), rel, str(v), attrs)
@@ -362,6 +364,8 @@ class DotMotifTransformer(Transformer):
                 this_node = args[macro_args.index(this_node)]
                 self.node_constraint((this_node, this_key, op, that_node, that_key))
                 continue
+            else:
+                raise ValueError(f"Invalid macro call. Failed on rule: {rule}")
             # Get the arguments in-place. For example, if left is A,
             # and A is the first arg in macro["args"], then replace
             # all instances of A in the rules with the first arg

--- a/dotmotif/parsers/v2/grammar.lark
+++ b/dotmotif/parsers/v2/grammar.lark
@@ -1,24 +1,24 @@
 // See Extended Backus-Naur Form for more details.
-start: comment_or_block+
+start                   : comment_or_block+
 
 
 // Contents may be either comment or block.
-comment_or_block: block
-                | block ";"
+comment_or_block        : block
+                        | block ";"
 
 // Comments are signified by a hash followed by anything. Any line that follows
 // a comment hash is thrown away.
 
-?comment        : "#" COMMENT
+?comment                : "#" COMMENT
 
-// A block may consist of either an edge ("A -> B") or a "macro", which is
-// essentially an alias capability.
-block           : edge
-                | macro
-                | macro_call
-                | node_constraint
-                | automorphism_notation
-                | comment
+// A block may consist of either an edge ("A -> B"), a constraint, or a "macro".
+block                   : edge
+                        | named_edge
+                        | macro
+                        | macro_call
+                        | node_constraint
+                        | automorphism_notation
+                        | comment
 
 
 
@@ -28,27 +28,27 @@ block           : edge
 // is the same as:
 //     A -> B
 // While this is a simple case, this is an immensely powerful tool.
-macro           : variable "(" arglist ")" "{" macro_rules "}"
+macro                   : variable "(" arglist ")" "{" macro_rules "}"
 
 // A series of arguments to a macro
-?arglist        : variable ("," variable)*
+?arglist                : variable ("," variable)*
 
-macro_rules     : macro_block+
+macro_rules             : macro_block+
 
-?macro_block    : edge_macro
-                | macro_call_re
-                | comment
-                | macro_node_constraint
+?macro_block            : edge_macro
+                        | macro_call_re
+                        | comment
+                        | macro_node_constraint
 
 // A "hypothetical" edge that forms a subgraph structure.
-edge_macro      : node_id relation node_id
-                | node_id relation node_id "[" macro_edge_clauses "]"
+edge_macro              : node_id relation node_id
+                        | node_id relation node_id "[" macro_edge_clauses "]"
 
 
 
 // A macro is called like a function: foo(args).
-macro_call      : variable "(" arglist ")"
-?macro_call_re  : variable "(" arglist ")"
+macro_call              : variable "(" arglist ")"
+?macro_call_re          : variable "(" arglist ")"
 
 
 
@@ -56,29 +56,35 @@ macro_call      : variable "(" arglist ")"
 // words, an arbitrary word, a relation between them, and then another node.
 // Edges can also have optional edge attributes, delimited from the original
 // structure with square brackets.
-edge            : node_id relation node_id
-                | node_id relation node_id "[" edge_clauses "]"
+edge                    : node_id relation node_id
+                        | node_id relation node_id "[" edge_clauses "]"
+
+named_edge              : node_id relation node_id "as" edge_alias
+                        | node_id relation node_id "[" edge_clauses "]" "as" edge_alias
+
+// An edge alias is any variable-like token:
+?edge_alias             : variable
 
 // A Node ID is any contiguous (that is, no whitespace) word.
-?node_id        : variable
+?node_id                : variable
 
 // A relation is a bipartite: The first character is an indication of whether
 // the relation exists or not. The following characters indicate if a relation
 // has a type other than the default, positive, and negative types offered
 // by default.
-relation        : relation_exist relation_type
+relation                : relation_exist relation_type
 
 // A "-" means the relation exists; "~" means the relation does not exist.
-relation_exist  : "-"                               -> rel_exist
-                | "~"                               -> rel_nexist
-                | "!"                               -> rel_nexist
+relation_exist          : "-"                               -> rel_exist
+                        | "~"                               -> rel_nexist
+                        | "!"                               -> rel_nexist
 
 // The valid types of relation are single-character, except for the custom
 // relation type which is user-defined and lives inside square brackets.
-relation_type   : ">"                               -> rel_def
-                | "+"                               -> rel_pos
-                | "-"                               -> rel_neg
-                | "|"                               -> rel_neg
+relation_type           : ">"                               -> rel_def
+                        | "+"                               -> rel_pos
+                        | "-"                               -> rel_neg
+                        | "|"                               -> rel_neg
 
 // Edge attributes are separated from the main edge declaration with sqbrackets
 edge_clauses            : edge_clause ("," edge_clause)*
@@ -131,25 +137,25 @@ automorphism_notation: node_id "===" node_id
 ?value_or_quoted_value: WORD | NUMBER | DOUBLE_QUOTED_STRING
 
 
-?key            : WORD | variable
-?flex_key       : WORD | variable | FLEXIBLE_KEY
-?value          : WORD | NUMBER
-?op             : OPERATOR | iter_ops
+?key                    : WORD | variable
+?flex_key               : WORD | variable | FLEXIBLE_KEY
+?value                  : WORD | NUMBER
+?op                     : OPERATOR | iter_ops
 
 
-variable       : NAME
+variable                : NAME
 
-iter_ops        : "contains"                        -> iter_op_contains
-                | "in"                              -> iter_op_in
-                | "!contains"                       -> iter_op_not_contains
-                | "!in"                             -> iter_op_not_in
+iter_ops                : "contains"                        -> iter_op_contains
+                        | "in"                              -> iter_op_in
+                        | "!contains"                       -> iter_op_not_contains
+                        | "!in"                             -> iter_op_not_in
 
-NAME            : /[a-zA-Z_-]\w*/
-FLEXIBLE_KEY    : "\"" /.+?/ /(?<!\\)(\\\\)*?/ "\"" | "'" /.+?/ /(?<!\\)(\\\\)*?/ "'"
-OPERATOR        : /(?:[\!=\>\<][=]?)|(?:\<\>)/
-VAR_SEP         : /[\_\-]/
-COMMENT         : /#[^\n]+/
-DOUBLE_QUOTED_STRING  : /"[^"]*"/
+NAME                    : /[a-zA-Z_-]\w*/
+FLEXIBLE_KEY            : "\"" /.+?/ /(?<!\\)(\\\\)*?/ "\"" | "'" /.+?/ /(?<!\\)(\\\\)*?/ "'"
+OPERATOR                : /(?:[\!=\>\<][=]?)|(?:\<\>)/
+VAR_SEP                 : /[\_\-]/
+COMMENT                 : /#[^\n]+/
+DOUBLE_QUOTED_STRING    : /"[^"]*"/
 %ignore COMMENT
 
 %import common.WORD -> WORD

--- a/dotmotif/parsers/v2/test_v2_parser.py
+++ b/dotmotif/parsers/v2/test_v2_parser.py
@@ -41,6 +41,22 @@ class TestDotmotif_Parserv2_DM(unittest.TestCase):
         dm = dotmotif.Motif(_THREE_CYCLE_NEG_INH)
         self.assertEqual([e[2]["exists"] for e in dm._g.edges(data=True)], [False] * 3)
 
+    def test_can_create_variables(self):
+        dm = dotmotif.Motif("""A -> B""")
+        self.assertEqual(len(dm._g.nodes()), 2)
+
+    def test_can_create_variables_with_underscores(self):
+        dm = dotmotif.Motif("""A -> B_""")
+        self.assertEqual(len(dm._g.nodes()), 2)
+
+    def test_cannot_create_variables_with_dashes(self):
+        with self.assertRaises(Exception):
+            dm = dotmotif.Motif("""A -> B-""")
+
+    def test_can_create_variables_with_numbers(self):
+        dm = dotmotif.Motif("""A_2 -> B1""")
+        self.assertEqual(len(dm._g.nodes()), 2)
+
 
 class TestDotmotif_Parserv2_DM_Macros(unittest.TestCase):
     def test_macro_not_added(self):
@@ -474,3 +490,32 @@ class TestDynamicNodeConstraints(unittest.TestCase):
         """
         dm = dotmotif.Motif(exp)
         self.assertEqual(len(dm.list_dynamic_node_constraints()), 1)
+
+
+class TestEdgeAliasConstraints(unittest.TestCase):
+    def test_can_create_aliases(self):
+        dotmotif.Motif("""A -> B as ab""")
+        assert True
+
+    def test_can_create_aliases_with_constraints(self):
+        dotmotif.Motif("""A -> B [type != 1] as ab_2""")
+        assert True
+
+    def test_can_create_alised_edge_constraints_nondynamic(self):
+        dotmotif.Motif(
+            """
+        A -> B [type != 1] as ab_2
+        ab_2.flavor = "excitatory"
+        """
+        )
+        assert True
+
+    def test_can_create_alised_edge_constraints_dynamic(self):
+        dotmotif.Motif(
+            """
+        A -> B [type != 1] as ab_2
+        B -> A as ba
+        ab_2.flavor = ba.flavor
+        """
+        )
+        assert True

--- a/dotmotif/parsers/v2/test_v2_parser.py
+++ b/dotmotif/parsers/v2/test_v2_parser.py
@@ -491,6 +491,20 @@ class TestDynamicNodeConstraints(unittest.TestCase):
         dm = dotmotif.Motif(exp)
         self.assertEqual(len(dm.list_dynamic_node_constraints()), 1)
 
+    def test_failed_node_lookup(self):
+        """
+        Test that comparisons may be made between variables, e.g.:
+
+        A.type != B.type
+
+        """
+        exp = """\
+        A -> B
+        C.radius < B.radius
+        """
+        with self.assertRaises(KeyError):
+            dm = dotmotif.Motif(exp)
+
 
 class TestEdgeAliasConstraints(unittest.TestCase):
     def test_can_create_aliases(self):
@@ -519,3 +533,17 @@ class TestEdgeAliasConstraints(unittest.TestCase):
         """
         )
         assert True
+
+    def test_failed_edge_lookup(self):
+        """
+        Test that comparisons may be made between variables, e.g.:
+
+        A.type != B.type
+
+        """
+        exp = """\
+        A -> B as ab
+        acb.radius = 3
+        """
+        with self.assertRaises(KeyError):
+            dm = dotmotif.Motif(exp)

--- a/dotmotif/parsers/v2/test_v2_parser.py
+++ b/dotmotif/parsers/v2/test_v2_parser.py
@@ -547,3 +547,27 @@ class TestEdgeAliasConstraints(unittest.TestCase):
         """
         with self.assertRaises(KeyError):
             dm = dotmotif.Motif(exp)
+
+    def test_quoted_attribute_edge_constraint(self):
+        exp = """\
+        A -> B as ab
+        ab["flavor"] = "excitatory"
+        """
+        dm = dotmotif.Motif(exp)
+        self.assertEqual(len(dm.list_edge_constraints()), 1)
+        self.assertEqual(
+            dm.list_edge_constraints()[("A", "B")]["flavor"]["="], ["excitatory"]
+        )
+
+    def test_quoted_attribute_dynamic_edge_constraint(self):
+        exp = """\
+        A -> B as ab
+        B -> A as ba
+        ab["flavor"] = ba["flavor"]
+        """
+        dm = dotmotif.Motif(exp)
+        self.assertEqual(len(dm.list_dynamic_edge_constraints()), 1)
+        self.assertEqual(
+            dm.list_dynamic_edge_constraints()[("A", "B")]["flavor"]["="],
+            ["B", "A", "flavor"],
+        )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ python setup.py sdist
 twine upload dist/*
 """
 
-VERSION = "0.11.0"
+VERSION = "0.12.0"
 
 here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, "README.md"), encoding="utf-8") as f:


### PR DESCRIPTION
This PR adds support for edge aliases (first described in #110) and comparisons between edge attributes with values and with other edges.

This enables syntax like this:

```py
A -> B as ab
B -> A as ba

ab.weight > ba.weight
```

- [x] Add support in the DSL
- [x] Add support in the parser + transformer
- [x] Add support in the executors:
  - [x] GrandIso
  - [x] NetworkX
  - [x] NeuPrint
  - [x] Neo4j

I am going to push macro support in a separate PR, since this one is getting pretty lengthy already!