### PR TITLE
Add macro edge aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
--   **?.?.?** (Unreleased)
+-   **0.12.0** (June 7 2022)
     -   Housekeeping:
         -   Removed old, deprecated code like the v1 parser (deprecated in `v0.5.0`) and some unused ingest tools (#113)
+    -   Features:
+        -   Added edge aliases and inter-edge attribute constraints
 -   **0.11.0** (April 12 2022)
     -   Features:
         -   Added support for attributes that include spaces and other non-word/variable characters, and updated Cypher syntax for these attributes when searching with Neo4j and neuPrint (#112)

--- a/dotmotif/executors/test_grandisoexecutor.py
+++ b/dotmotif/executors/test_grandisoexecutor.py
@@ -257,38 +257,6 @@ class TestSmallMotifs(unittest.TestCase):
         res = GrandIsoExecutor(graph=G).find(motif)
         self.assertEqual(len(res), 3)
 
-    def test_nested_macros_with_node_constraint(self):
-        G = nx.DiGraph()
-        G.add_edge("A", "B")
-        G.add_edge("B", "C")
-        G.add_edge("C", "A")
-        G.add_node("A", type="foo")
-        G.add_node("B", type="foo")
-        G.add_node("C", type="foo")
-
-        motif = dotmotif.Motif(
-            """
-            tri(A, B, C) {
-                A -> B
-                B -> C
-                C -> A
-                A.type = "foo"
-            }
-
-            tri2(A1, B1, C1) {
-                tri(A1, B1, C1)
-            }
-
-            tri3(A2, B2, C2) {
-                tri2(A2, B2, C2)
-            }
-
-            tri3(A3, B3, C3)
-            """
-        )
-        res = GrandIsoExecutor(graph=G).find(motif)
-        self.assertEqual(len(res), 3)
-
 
 class TestDynamicNodeConstraints(unittest.TestCase):
     def test_dynamic_constraints_zero_results(self):
@@ -593,15 +561,7 @@ class TestEdgeConstraintsInMacros(unittest.TestCase):
             ab.weight == 1
         }
 
-        b(a2, b2) {
-            a(a2, b2)
-        }
-
-        c(a3, b3) {
-            b(a3, b3)
-        }
-
-        c(A, B)
+        a(A, B)
         """
         )
 
@@ -623,17 +583,100 @@ class TestEdgeConstraintsInMacros(unittest.TestCase):
             ab.length > ab.weight
         }
 
-        b(a2, b2) {
-            a(a2, b2)
-        }
-
-        c(a3, b3) {
-            b(a3, b3)
-        }
-
-        c(A, B)
+        a(A, B)
         """
         )
 
         E = GrandIsoExecutor(graph=host)
         assert E.count(M) == 1
+
+
+# class TestDeepNestingMacros(unittest.TestCase):
+
+#     def test_nested_macros_with_node_constraint(self):
+#         G = nx.DiGraph()
+#         G.add_edge("A", "B")
+#         G.add_edge("B", "C")
+#         G.add_edge("C", "A")
+#         G.add_node("A", type="foo")
+#         G.add_node("B", type="foo")
+#         G.add_node("C", type="foo")
+
+#         motif = dotmotif.Motif(
+#             """
+#             tri(A, B, C) {
+#                 A -> B
+#                 B -> C
+#                 C -> A
+#                 A.type = "foo"
+#             }
+
+#             tri2(A1, B1, C1) {
+#                 tri(A1, B1, C1)
+#             }
+
+#             tri3(A2, B2, C2) {
+#                 tri2(A2, B2, C2)
+#             }
+
+#             tri3(A3, B3, C3)
+#             """
+#         )
+#         res = GrandIsoExecutor(graph=G).find(motif)
+#         self.assertEqual(len(res), 3)
+
+
+#     def test_deep_nested_macro_edge_constraints(self):
+#         host = nx.DiGraph()
+#         M = Motif(
+#             """
+#         a(a1, b1) {
+#             b1 -> a1
+#             a1 -> b1 as ab
+#             ab.weight == 1
+#         }
+
+#         b(a2, b2) {
+#             a(a2, b2)
+#         }
+
+#         c(a3, b3) {
+#             b(a3, b3)
+#         }
+
+#         c(A, B)
+#         """
+#         )
+
+#         host.add_edge("A", "B", weight=1)
+#         host.add_edge("B", "A", weight=0.5)
+#         E = GrandIsoExecutor(graph=host)
+#         assert E.count(M) == 1
+
+#     def test_deep_self_edge_constraints(self):
+#         host = nx.DiGraph()
+#         host.add_edge("A", "B", weight=1, length=2)
+#         host.add_edge("B", "A", weight=1, length=1)
+
+#         M = Motif(
+#             """
+#         a(a1, b1) {
+#             b1 -> a1
+#             a1 -> b1 as ab
+#             ab.length > ab.weight
+#         }
+
+#         b(a2, b2) {
+#             a(a2, b2)
+#         }
+
+#         c(a3, b3) {
+#             b(a3, b3)
+#         }
+
+#         c(A, B)
+#         """
+#         )
+
+#         E = GrandIsoExecutor(graph=host)
+#         assert E.count(M) == 1

--- a/dotmotif/executors/test_grandisoexecutor.py
+++ b/dotmotif/executors/test_grandisoexecutor.py
@@ -521,5 +521,58 @@ class TestEdgeConstraintsInMacros(unittest.TestCase):
 
         """
         )
-        print(E.find(M))
+        assert E.count(M) == 1
+
+    def test_nested_macro_edge_constraints(self):
+        host = nx.DiGraph()
+        M = Motif(
+            """
+        a(a1, b1) {
+            b1 -> a1
+            a1 -> b1 as ab
+        }
+
+        b(a2, b2) {
+            a(a2, b2)
+        }
+
+        c(a3, b3) {
+            b(a3, b3)
+        }
+
+        c(A, B)
+        """
+        )
+
+        host.add_edge("A", "B", weight=1)
+        host.add_edge("B", "A", weight=0.5)
+        E = GrandIsoExecutor(graph=host)
+        assert E.count(M) == 1
+
+    def test_self_edge_constraints(self):
+        host = nx.DiGraph()
+        host.add_edge("A", "B", weight=1, length=2)
+        host.add_edge("B", "A", weight=1, length=1)
+
+        M = Motif(
+            """
+        a(a1, b1) {
+            b1 -> a1
+            a1 -> b1 as ab
+            ab.length > ab.weight
+        }
+
+        b(a2, b2) {
+            a(a2, b2)
+        }
+
+        c(a3, b3) {
+            b(a3, b3)
+        }
+
+        c(A, B)
+        """
+        )
+
+        E = GrandIsoExecutor(graph=host)
         assert E.count(M) == 1

--- a/dotmotif/executors/test_grandisoexecutor.py
+++ b/dotmotif/executors/test_grandisoexecutor.py
@@ -475,30 +475,51 @@ class TestNamedEdgeConstraints(unittest.TestCase):
         self.assertEqual(len(res), 2)
 
 
-# class TestEdgeConstraintsInMacros(unittest.TestCase):
-#     def test_edge_comparison_in_macro(self):
-#         host = nx.DiGraph()
-#         host.add_edge("A", "B", foo=1)
-#         host.add_edge("A", "C", foo=2)
-#         host.add_edge("B", "C", foo=0.5)
-#         host.add_edge("C", "D", foo=0.25)
-#         host.add_edge("D", "C", foo=1)
-#         host.add_edge("C", "B", foo=2)
-#         host.add_edge("B", "A", foo=2)
-#         E = GrandIsoExecutor(graph=host)
+class TestEdgeConstraintsInMacros(unittest.TestCase):
+    def test_edge_comparison_in_macro(self):
+        host = nx.DiGraph()
+        host.add_edge("A", "B", foo=1)
+        host.add_edge("B", "C", foo=0.5)
+        host.add_edge("C", "D", foo=0.25)
+        E = GrandIsoExecutor(graph=host)
 
-#         M = Motif(
-#             """
+        M = Motif(
+            """
 
-#         descending(a, b, c) {
-#             a -> b as Edge1
-#             b -> c as Edge2
-#             Edge1.foo > Edge2.foo
-#         }
+        descending(a, b) {
+            a -> b as Edge1
+            Edge1.foo >= 1
+        }
 
-#         descending(a, b, c)
-#         descending(b, c, d)
+        descending(real_a, real_b)
 
-#         """
-#         )
-#         assert E.count(M) == 1
+        """
+        )
+        assert E.count(M) == 1
+
+    def test_dynamic_edge_comparison_in_macro(self):
+        host = nx.DiGraph()
+        host.add_edge("A", "B", foo=1)
+        host.add_edge("B", "C", foo=0.5)
+        host.add_edge("C", "D", foo=0.25)
+        host.add_edge("D", "C", foo=1)
+        host.add_edge("C", "B", foo=2)
+        host.add_edge("B", "A", foo=2)
+        E = GrandIsoExecutor(graph=host)
+
+        M = Motif(
+            """
+
+        descending(a, b, c) {
+            a -> b as Edge1
+            b -> c as Edge2
+            Edge1.foo > Edge2.foo
+        }
+
+        descending(a, b, c)
+        descending(b, c, d)
+
+        """
+        )
+        print(E.find(M))
+        assert E.count(M) == 1

--- a/dotmotif/parsers/v2/__init__.py
+++ b/dotmotif/parsers/v2/__init__.py
@@ -449,8 +449,35 @@ class DotMotifTransformer(Transformer):
                             f"named edge '{this_node}' but named edge "
                             f"'{that_node}' does not exist."
                         )
-                    # left, right, attrs = named_edges[this_node]
-                    # attrs[this_key] = (op, that_node, that_key)
+                    # We will copy similar behavior from the simple case above,
+                    # by creating a named edge for the motif and then adding
+                    # the constraint to that edge through the node_constraint
+                    # method.
+                    left, right, named_edge_attrs = named_edges[this_node]
+                    real_this_left = args[macro_args.index(left)]
+                    real_this_right = args[macro_args.index(right)]
+                    random_this_name = f"{this_node}_{str(uuid.uuid4())}"
+                    # Now do the same for the that edge:
+                    left, right, named_edge_attrs = named_edges[that_node]
+                    real_that_left = args[macro_args.index(left)]
+                    real_that_right = args[macro_args.index(right)]
+                    random_that_name = f"{that_node}_{str(uuid.uuid4())}"
+                    # Temporarily add these edges to the motif's named edges,
+                    # with random names.
+                    self.named_edges[random_this_name] = (
+                        real_this_left,
+                        real_this_right,
+                        named_edge_attrs,
+                    )
+                    self.named_edges[random_that_name] = (
+                        real_that_left,
+                        real_that_right,
+                        named_edge_attrs,
+                    )
+                    self.node_constraint(
+                        (random_this_name, this_key, op, random_that_name, that_key)
+                    )
+
                 else:
                     # This is a dynamic node constraint.
                     this_node = args[macro_args.index(this_node)]

--- a/dotmotif/parsers/v2/grammar.lark
+++ b/dotmotif/parsers/v2/grammar.lark
@@ -36,6 +36,7 @@ macro                   : variable "(" arglist ")" "{" macro_rules "}"
 macro_rules             : macro_block+
 
 ?macro_block            : edge_macro
+                        | named_edge_macro
                         | macro_call_re
                         | comment
                         | macro_node_constraint
@@ -43,7 +44,6 @@ macro_rules             : macro_block+
 // A "hypothetical" edge that forms a subgraph structure.
 edge_macro              : node_id relation node_id
                         | node_id relation node_id "[" macro_edge_clauses "]"
-
 
 
 // A macro is called like a function: foo(args).
@@ -60,6 +60,9 @@ edge                    : node_id relation node_id
                         | node_id relation node_id "[" edge_clauses "]"
 
 named_edge              : node_id relation node_id "as" edge_alias
+                        | node_id relation node_id "[" edge_clauses "]" "as" edge_alias
+
+named_edge_macro        : node_id relation node_id "as" edge_alias
                         | node_id relation node_id "[" edge_clauses "]" "as" edge_alias
 
 // An edge alias is any variable-like token:

--- a/dotmotif/parsers/v2/test_v2_parser.py
+++ b/dotmotif/parsers/v2/test_v2_parser.py
@@ -571,3 +571,28 @@ class TestEdgeAliasConstraints(unittest.TestCase):
             dm.list_dynamic_edge_constraints()[("A", "B")]["flavor"]["="],
             ["B", "A", "flavor"],
         )
+
+
+class TestEdgeConstraintsInMacro(unittest.TestCase):
+    def test_simple_edge_constraint_in_macro(self):
+        exp = """\
+        macro(A, B) {
+            A -> B as ab
+            ab.radius > 1
+        }
+        macro(A, B)
+        """
+        dm = dotmotif.Motif(exp)
+        self.assertEqual(len(dm.list_edge_constraints()), 1)
+
+    # def test_dynamic_edge_constraint_in_macro(self):
+    #     exp = """\
+    #     macro(A, B) {
+    #         A -> B as ab
+    #         B -> A as ba
+    #         ab.weight > ba.weight
+    #     }
+    #     macro(A, B)
+    #     """
+    #     dm = dotmotif.Motif(exp)
+    #     self.assertEqual(len(dm.list_dynamic_edge_constraints()), 1)


### PR DESCRIPTION
This adds support for complex edge constraints in macros:

```py
decreasing_edge_weights(a, b, c) {
    a -> b as ab
    b -> c as bc
    ab.weight > bc.weight
}

...
```

In increasing levels of challengingness:
- [x] Add support for simple (edge-value) edge constraints in macros
- [x] Add support for dynamic (edge-edge) edge constraints in macros
- [x] Extend support for recursive calls to macros with simple constraints
- [x] Extend support for recursive calls to macros with dynamic constraints
- [x] Update documentation

This fixes #110 and finishes work started in #119.