### PR TITLE
fix: weight edge attribute doesn't throw errors anymore (#127)

### DIFF
--- a/dotmotif/executors/NeuPrintExecutor.py
+++ b/dotmotif/executors/NeuPrintExecutor.py
@@ -137,17 +137,19 @@ class NeuPrintExecutor(Neo4jExecutor):
             for (u, v), a in motif.list_edge_constraints().items():
                 for key, constraints in a.items():
                     key = key.strip('"')  # remove quotes if any
-                    attribute, sub_attribute = key.split(".")
-                    if attribute in json_attributes:
-                        for operator, values in constraints.items():
-                            for value in values:
-                                this_edge = """{}_{}["{}"] {} {}""".format(
-                                    u, v, key, operator, str(value)
-                                )
-                                that_edge = """(apoc.convert.fromJsonMap({}.roiInfo)["{}"].{} {} {})""".format(
-                                    u, attribute, sub_attribute, operator, str(value)
-                                )
-                                cypher = cypher.replace(this_edge, that_edge)
-                    else:
-                        print("Unknown JSON edge constraint: {}".format(key))
+                    if "." in key:
+                        attribute, sub_attribute = key.split(".")
+                        if attribute in json_attributes:
+                            for operator, values in constraints.items():
+                                for value in values:
+                                    this_edge = """{}_{}["{}"] {} {}""".format(
+                                        u, v, key, operator, str(value)
+                                    )
+                                    that_edge = """(apoc.convert.fromJsonMap({}.roiInfo)["{}"].{} {} {})""".format(
+                                        u, attribute, sub_attribute, operator, str(value)
+                                    )
+                                    cypher = cypher.replace(this_edge, that_edge)
+                        else:
+                            print("Unknown JSON edge constraint: {}".format(key))
+
         return cypher

--- a/dotmotif/executors/test_neuprintexecutor.py
+++ b/dotmotif/executors/test_neuprintexecutor.py
@@ -67,7 +67,7 @@ if TOKEN:
         def test_edge_constraints_notation2(self):
             motif = Motif().from_motif(
                 """
-                A -> B ["CRE(L).pre" > 10, "CX.post" > 20]
+                A -> B [weight > 10, "CRE(L).pre" > 10, "CX.post" > 20]
                 """
             )
             E = NeuPrintExecutor(HOST, DATASET, TOKEN)


### PR DESCRIPTION
The edge attribute in the neuprint executor threw an error with the new JSON feature implementation. I also made the neuprint executor tests more rigorous. 