### PR TITLE
Fix constraint and Cypher handling

### DIFF
--- a/dotmotif/executors/Neo4jExecutor.py
+++ b/dotmotif/executors/Neo4jExecutor.py
@@ -15,6 +15,7 @@ limitations under the License.`
 """
 
 from itertools import product
+import json
 
 try:
     from py2neo import Graph
@@ -88,6 +89,20 @@ def _quoted_if_necessary(val: str) -> str:
         return '"' + val + '"'
     else:
         return '"' + val + '"'
+
+
+def _cypher_literal(value) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, (list, tuple)):
+        return "[" + ", ".join(_cypher_literal(item) for item in value) + "]"
+    return str(value)
 
 
 _LOOKUP = {
@@ -251,13 +266,20 @@ class Neo4jExecutor(Executor):
 
         # ID that is assigned to it so that it can hold constraints later on.
         edge_mapping = {}
+        edge_counts = {}
+        for u, v in motif_graph.edges():
+            edge_counts[(u, v)] = edge_counts.get((u, v), 0) + 1
 
-        for u, v, a in motif_graph.edges(data=True):
+        for u, v, key, a in motif_graph.edges(keys=True, data=True):
             action = static_entity_labels["edge"][
                 a.get("action", static_entity_labels["edge"]["DEFAULT"])
             ]
-            edge_id = "{}_{}".format(u, v)
-            edge_mapping[(u, v)] = edge_id
+            edge_id = (
+                "{}_{}_{}".format(u, v, key)
+                if edge_counts[(u, v)] > 1
+                else "{}_{}".format(u, v)
+            )
+            edge_mapping.setdefault((u, v), edge_id)
             if a["exists"]:
                 es.append(
                     (
@@ -324,7 +346,7 @@ class Neo4jExecutor(Executor):
                                 edge_mapping[(u, v)],
                                 _quoted_if_necessary(key),
                                 _remapped_operator(operator),
-                                f'"{value}"' if isinstance(value, str) else value,
+                                _cypher_literal(value),
                             )
                         )
 
@@ -343,7 +365,7 @@ class Neo4jExecutor(Executor):
                                 n,
                                 _quoted_if_necessary(key),
                                 _remapped_operator(operator),
-                                f'"{value}"' if isinstance(value, str) else value,
+                                _cypher_literal(value),
                             )
                         )
 
@@ -371,22 +393,23 @@ class Neo4jExecutor(Executor):
         # {('A', 'B'): {'weight': {'==': ['A', 'C', 'weight']}}}
         for (u, v), constraints in motif.list_dynamic_edge_constraints().items():
             for this_attr, ops in constraints.items():
-                for op, (that_u, that_v, that_attr) in ops.items():
-                    this_edge_name = edge_mapping[(u, v)]
-                    that_edge_name = edge_mapping[(that_u, that_v)]
-                    cypher_edge_constraints.append(
-                        (
-                            "NOT ({}[{}] {} {}[{}])"
-                            if _operator_negation_infix(op)
-                            else "{}[{}] {} {}[{}]"
-                        ).format(
-                            this_edge_name,
-                            _quoted_if_necessary(this_attr),
-                            _remapped_operator(op),
-                            that_edge_name,
-                            _quoted_if_necessary(that_attr),
+                for op, targets in ops.items():
+                    for that_u, that_v, that_attr in targets:
+                        this_edge_name = edge_mapping[(u, v)]
+                        that_edge_name = edge_mapping[(that_u, that_v)]
+                        cypher_edge_constraints.append(
+                            (
+                                "NOT ({}[{}] {} {}[{}])"
+                                if _operator_negation_infix(op)
+                                else "{}[{}] {} {}[{}]"
+                            ).format(
+                                this_edge_name,
+                                _quoted_if_necessary(this_attr),
+                                _remapped_operator(op),
+                                that_edge_name,
+                                _quoted_if_necessary(that_attr),
+                            )
                         )
-                    )
 
         conditions.extend([*cypher_node_constraints, *cypher_edge_constraints])
 

--- a/dotmotif/executors/Neo4jExecutor.py
+++ b/dotmotif/executors/Neo4jExecutor.py
@@ -16,6 +16,7 @@ limitations under the License.`
 
 from itertools import product
 import json
+import math
 
 try:
     from py2neo import Graph
@@ -102,7 +103,11 @@ def _cypher_literal(value) -> str:
         return json.dumps(value, ensure_ascii=False)
     if isinstance(value, (list, tuple)):
         return "[" + ", ".join(_cypher_literal(item) for item in value) + "]"
-    return str(value)
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float) and math.isfinite(value):
+        return str(value)
+    raise TypeError(f"Unsupported Cypher literal: {value!r}")
 
 
 _LOOKUP = {
@@ -269,6 +274,26 @@ class Neo4jExecutor(Executor):
         edge_counts = {}
         for u, v in motif_graph.edges():
             edge_counts[(u, v)] = edge_counts.get((u, v), 0) + 1
+
+        constrained_edges = {
+            edge for edge, constraints in motif.list_edge_constraints().items() if constraints
+        } | {
+            edge
+            for edge, constraints in motif.list_dynamic_edge_constraints().items()
+            if constraints
+        }
+        for constraints in motif.list_dynamic_edge_constraints().values():
+            for operators in constraints.values():
+                for targets in operators.values():
+                    constrained_edges.update((u, v) for u, v, _ in targets)
+        ambiguous_edges = {
+            edge for edge in constrained_edges if edge_counts.get(edge, 0) > 1
+        }
+        if ambiguous_edges:
+            raise ValueError(
+                "Cypher generation cannot assign endpoint-based constraints to "
+                f"parallel motif edges: {sorted(ambiguous_edges)}"
+            )
 
         for u, v, key, a in motif_graph.edges(keys=True, data=True):
             action = static_entity_labels["edge"][

--- a/dotmotif/executors/NetworkXExecutor.py
+++ b/dotmotif/executors/NetworkXExecutor.py
@@ -271,19 +271,20 @@ class NetworkXExecutor(Executor):
         """
         for (motif_U, motif_V), constraint_list in constraints.items():
             for this_attr, ops in constraint_list.items():
-                for op, (that_u, that_v, that_attr) in ops.items():
-                    this_graph_u = node_isomorphism_map[motif_U]
-                    this_graph_v = node_isomorphism_map[motif_V]
-                    that_graph_u = node_isomorphism_map[that_u]
-                    that_graph_v = node_isomorphism_map[that_v]
-                    this_edge_attr = graph.get_edge_data(
-                        this_graph_u, this_graph_v
-                    ).get(this_attr)
-                    that_edge_attr = graph.get_edge_data(
-                        that_graph_u, that_graph_v
-                    ).get(that_attr)
-                    if not _OPERATORS[op](this_edge_attr, that_edge_attr):
-                        return False
+                for op, targets in ops.items():
+                    for that_u, that_v, that_attr in targets:
+                        this_graph_u = node_isomorphism_map[motif_U]
+                        this_graph_v = node_isomorphism_map[motif_V]
+                        that_graph_u = node_isomorphism_map[that_u]
+                        that_graph_v = node_isomorphism_map[that_v]
+                        this_edge_attr = graph.get_edge_data(
+                            this_graph_u, this_graph_v
+                        ).get(this_attr)
+                        that_edge_attr = graph.get_edge_data(
+                            that_graph_u, that_graph_v
+                        ).get(that_attr)
+                        if not _OPERATORS[op](this_edge_attr, that_edge_attr):
+                            return False
         return True
 
     def _validate_multigraph_all_edge_constraints(

--- a/dotmotif/executors/NeuPrintExecutor.py
+++ b/dotmotif/executors/NeuPrintExecutor.py
@@ -134,21 +134,17 @@ class NeuPrintExecutor(Neo4jExecutor):
 
         # Replace the JSON attributes with the neuprint-specific ones
         if json_attributes:
-            for (u, v), a in motif.list_edge_constraints().items():
-                for key, constraints in a.items():
+            for (u, v), attributes in motif.list_edge_constraints().items():
+                for key in attributes:
                     key = key.strip('"')  # remove quotes if any
                     if "." in key:
-                        attribute, sub_attribute = key.split(".")
+                        attribute, sub_attribute = key.split(".", 1)
                         if attribute in json_attributes:
-                            for operator, values in constraints.items():
-                                for value in values:
-                                    this_edge = """{}_{}["{}"] {} {}""".format(
-                                        u, v, key, operator, str(value)
-                                    )
-                                    that_edge = """(apoc.convert.fromJsonMap({}_{}.roiInfo)["{}"].{} {} {})""".format(
-                                        u, v, attribute, sub_attribute, operator, str(value)
-                                    )
-                                    cypher = cypher.replace(this_edge, that_edge)
+                            this_property = '{}_{}["{}"]'.format(u, v, key)
+                            roi_property = (
+                                '(apoc.convert.fromJsonMap({}_{}.roiInfo)["{}"].{})'
+                            ).format(u, v, attribute, sub_attribute)
+                            cypher = cypher.replace(this_property, roi_property)
                         else:
                             print("Unknown JSON edge constraint: {}".format(key))
 

--- a/dotmotif/executors/test_dm_cypher.py
+++ b/dotmotif/executors/test_dm_cypher.py
@@ -252,6 +252,12 @@ class TestDynamicEdgeConstraints(unittest.TestCase):
         self.assertIn("[A_B_0:SYN]", cypher)
         self.assertIn("[A_B_1:INH]", cypher)
 
+    def test_parallel_edge_constraints_are_rejected_as_ambiguous(self):
+        dm = dotmotif.Motif("A -> B [weight > 1]\nA -| B")
+
+        with self.assertRaisesRegex(ValueError, "parallel motif edges"):
+            Neo4jExecutor.motif_to_cypher(dm)
+
 
 class BugReports(unittest.TestCase):
     def test_fix_where_clause__github_35(self):

--- a/dotmotif/executors/test_dm_cypher.py
+++ b/dotmotif/executors/test_dm_cypher.py
@@ -230,6 +230,28 @@ class TestDynamicEdgeConstraints(unittest.TestCase):
             Neo4jExecutor.motif_to_cypher(dm).strip(),
         )
 
+    def test_multiple_dynamic_constraints_in_cypher(self):
+        dm = dotmotif.Motif(
+            """
+        A -> B as AB
+        A -> C as AC
+        AB.weight >= AC.weight
+        AB.weight >= AC.capacity
+        """
+        )
+        cypher = Neo4jExecutor.motif_to_cypher(dm)
+
+        self.assertIn('A_B["weight"] >= A_C["weight"]', cypher)
+        self.assertIn('A_B["weight"] >= A_C["capacity"]', cypher)
+
+    def test_parallel_edges_have_unique_variables(self):
+        dm = dotmotif.Motif("A -> B\nA -| B")
+
+        cypher = Neo4jExecutor.motif_to_cypher(dm)
+
+        self.assertIn("[A_B_0:SYN]", cypher)
+        self.assertIn("[A_B_1:INH]", cypher)
+
 
 class BugReports(unittest.TestCase):
     def test_fix_where_clause__github_35(self):

--- a/dotmotif/executors/test_neo4jexecutor.py
+++ b/dotmotif/executors/test_neo4jexecutor.py
@@ -1,5 +1,9 @@
 import dotmotif
-from dotmotif.executors.Neo4jExecutor import Neo4jExecutor, _quoted_if_necessary
+from dotmotif.executors.Neo4jExecutor import (
+    Neo4jExecutor,
+    _cypher_literal,
+    _quoted_if_necessary,
+)
 import unittest
 
 
@@ -33,3 +37,6 @@ class TestQuotingIfNecessary(unittest.TestCase):
         self.assertEqual(_quoted_if_necessary("""don't break"""), '''"don't break"'''),
         self.assertEqual(_quoted_if_necessary("foo bar"), '"foo bar"')
         self.assertEqual(_quoted_if_necessary("foo"), '"foo"')
+
+    def test_cypher_string_literal_escaping(self):
+        self.assertEqual(_cypher_literal('say "hi"\nnext\\line'), '"say \\"hi\\"\\nnext\\\\line"')

--- a/dotmotif/executors/test_neo4jexecutor.py
+++ b/dotmotif/executors/test_neo4jexecutor.py
@@ -40,3 +40,9 @@ class TestQuotingIfNecessary(unittest.TestCase):
 
     def test_cypher_string_literal_escaping(self):
         self.assertEqual(_cypher_literal('say "hi"\nnext\\line'), '"say \\"hi\\"\\nnext\\\\line"')
+
+    def test_unsupported_cypher_literals_are_rejected(self):
+        with self.assertRaises(TypeError):
+            _cypher_literal({"key": "value"})
+        with self.assertRaises(TypeError):
+            _cypher_literal(float("nan"))

--- a/dotmotif/executors/test_neuprintexecutor.py
+++ b/dotmotif/executors/test_neuprintexecutor.py
@@ -1,14 +1,35 @@
 import os
 
+from .. import Motif
+from .NeuPrintExecutor import NeuPrintExecutor
+
 HOST = "neuprint.janelia.org"
 DATASET = "hemibrain:v1.1"
 TOKEN = os.getenv("NEUPRINT_TOKEN")
+
+
+def test_roi_constraints_are_rewritten_after_cypher_encoding():
+    motif = Motif(
+        """
+        A -> B as AB
+        AB["CRE(L).pre"] = "quoted value"
+        AB["CX.post"] != 20
+        """
+    )
+
+    cypher = NeuPrintExecutor.motif_to_cypher(
+        motif, json_attributes=["CRE(L)", "CX"]
+    )
+
+    assert 'A_B["CRE(L).pre"]' not in cypher
+    assert 'A_B["CX.post"]' not in cypher
+    assert 'fromJsonMap(A_B.roiInfo)["CRE(L)"].pre) = "quoted value"' in cypher
+    assert 'fromJsonMap(A_B.roiInfo)["CX"].post) <> 20' in cypher
+
+
 if TOKEN:
 
     import unittest
-
-    from .. import Motif
-    from .NeuPrintExecutor import NeuPrintExecutor
 
     class TestNeuPrintConnection(unittest.TestCase):
         def test_can_get_version(self):

--- a/dotmotif/parsers/v2/__init__.py
+++ b/dotmotif/parsers/v2/__init__.py
@@ -111,7 +111,7 @@ class DotMotifTransformer(Transformer):
                             tu, tv, _ = self.named_edges[that_edge]
                             if op not in self.dynamic_edge_constraints[(u, v)][key]:
                                 self.dynamic_edge_constraints[(u, v)][key][op] = []
-                            self.dynamic_edge_constraints[(u, v)][key][op].extend(
+                            self.dynamic_edge_constraints[(u, v)][key][op].append(
                                 (tu, tv, that_attr)
                             )
             else:

--- a/dotmotif/parsers/v2/test_v2_parser.py
+++ b/dotmotif/parsers/v2/test_v2_parser.py
@@ -569,7 +569,22 @@ class TestEdgeAliasConstraints(unittest.TestCase):
         self.assertEqual(len(dm.list_dynamic_edge_constraints()), 1)
         self.assertEqual(
             dm.list_dynamic_edge_constraints()[("A", "B")]["flavor"]["="],
-            ["B", "A", "flavor"],
+            [("B", "A", "flavor")],
+        )
+
+    def test_multiple_dynamic_edge_constraints(self):
+        dm = dotmotif.Motif(
+            """
+        A -> B as ab
+        A -> C as ac
+        ab.weight > ac.weight
+        ab.weight > ac.capacity
+        """
+        )
+
+        self.assertEqual(
+            dm.list_dynamic_edge_constraints()[("A", "B")]["weight"][">"],
+            [("A", "C", "weight"), ("A", "C", "capacity")],
         )
 
 


### PR DESCRIPTION
This fixes a few places where constraints could get mangled on their way from the parser to an executor.

- keeps multiple dynamic edge comparisons as separate triples instead of flattening them together
- makes both NetworkX and Neo4j evaluate every dynamic edge comparison
- escapes Cypher values instead of dropping raw strings into the query
- gives parallel motif relationships distinct Cypher variables while leaving the usual single-edge names alone