### PR TITLE
Fix motif lifecycle and edgelist ingest

### DIFF
--- a/dotmotif/__init__.py
+++ b/dotmotif/__init__.py
@@ -17,6 +17,7 @@ limitations under the License.
 
 from typing import List, Optional, Union, IO
 import copy
+import os
 import pickle
 import warnings
 from dotmotif.utils import _deep_merge_constraint_dicts
@@ -148,9 +149,14 @@ class Motif:
             DeprecationWarning,
         )
         self._g = copy.deepcopy(graph)
-        for u, v, edge_attrs in self._g.edges(data=True):
-            if "exists" not in edge_attrs:
-                self._g.edges[u, v]["exists"] = True
+        self._edge_constraints = {}
+        self._node_constraints = {}
+        self._dynamic_edge_constraints = {}
+        self._dynamic_node_constraints = {}
+        self._automorphisms = []
+        for _, _, edge_attrs in self._g.edges(data=True):
+            edge_attrs.setdefault("exists", True)
+            edge_attrs.setdefault("action", "SYN")
         return self
 
     def to_nx(self) -> nx.DiGraph:
@@ -232,11 +238,11 @@ class Motif:
             Pointer to File-like.
 
         """
-        if isinstance(fname, str):
-            f = open(fname, "wb")
+        if isinstance(fname, (str, os.PathLike)):
+            with open(fname, "wb") as f:
+                pickle.dump(self, f)
         else:
-            f = fname
-        pickle.dump(self, f)
+            pickle.dump(self, fname)
         return fname
 
     @staticmethod
@@ -251,13 +257,11 @@ class Motif:
             Pointer to File-like.
 
         """
-        if isinstance(fname, str):
-            f = open(fname, "rb")
+        if isinstance(fname, (str, os.PathLike)):
+            with open(fname, "rb") as f:
+                return pickle.load(f)
         else:
-            f = fname
-        result = pickle.load(f)
-        f.close()
-        return result
+            return pickle.load(fname)
 
 
 __all__ = ["Motif", "MotifError", "NetworkXExecutor", "GrandIsoExecutor"]

--- a/dotmotif/ingest/__init__.py
+++ b/dotmotif/ingest/__init__.py
@@ -1,7 +1,6 @@
 # Standard installs:
 import abc
 import os
-import numpy as np
 
 # Non-standard installs:
 import pandas as pd
@@ -39,29 +38,42 @@ class EdgelistConverter(NetworkXConverter):
         v_id_column_dtype=str,
     ):
         if isinstance(filepath_or_dataframe, pd.DataFrame):
-            data = filepath_or_dataframe
+            data = filepath_or_dataframe.copy()
         else:
             data = pd.read_table(
                 filepath_or_dataframe,
-                dtype={u_id_column: str, v_id_column: str},
                 **(file_reader_kwargs or {"sep": ","}),
             )
         if u_id_column not in data.columns:
             raise KeyError(f"Dataframe does not contain column {u_id_column}.")
         if v_id_column not in data.columns:
             raise KeyError(f"Dataframe does not contain column {v_id_column}.")
+        if data[[u_id_column, v_id_column]].isna().any().any():
+            raise ValueError("Edgelist endpoint columns cannot contain missing values.")
+
+        def _convert_ids(column, dtype):
+            if dtype is bool or isinstance(dtype, pd.BooleanDtype):
+                values = column.map(
+                    lambda value: {
+                        "true": True,
+                        "1": True,
+                        "false": False,
+                        "0": False,
+                    }.get(str(value).strip().lower(), value)
+                )
+            else:
+                values = column
+            return values.astype(dtype)
+
+        data[u_id_column] = _convert_ids(data[u_id_column], u_id_column_dtype)
+        data[v_id_column] = _convert_ids(data[v_id_column], v_id_column_dtype)
+        if data[[u_id_column, v_id_column]].isna().any().any():
+            raise ValueError("Edgelist endpoint columns cannot contain missing values.")
         self._graph = nx.DiGraph() if directed else nx.Graph()
         for i, row in data.iterrows():
-            if u_id_column_dtype is not str:
-                u = np.format_float_positional(row[u_id_column])
-            else:
-                u = row[u_id_column]
-
-            if v_id_column_dtype is not str:
-                v = np.format_float_positional(row[v_id_column])
-            else:
-                v = row[v_id_column]
-            self._graph.add_edge(u, v, **dict(row))
+            self._graph.add_edge(
+                row[u_id_column], row[v_id_column], **dict(row)
+            )
 
     def to_graph(self):
         return self._graph

--- a/dotmotif/ingest/test_ingest.py
+++ b/dotmotif/ingest/test_ingest.py
@@ -59,3 +59,72 @@ class TestEdgelistIngest(unittest.TestCase):
         converter = EdgelistConverter(df, "source", "target")
         graph = converter.to_graph()
         self.assertEqual(graph.number_of_nodes(), 3)
+
+    def test_endpoint_dtypes_apply_to_dataframes(self):
+        converter = EdgelistConverter(
+            pd.DataFrame([{"source": "1", "target": "2"}]),
+            "source",
+            "target",
+            u_id_column_dtype=int,
+            v_id_column_dtype=float,
+        )
+
+        self.assertEqual(set(converter.to_graph().nodes), {1, 2.0})
+
+    def test_endpoint_dtypes_apply_while_reading_files(self):
+        converter = EdgelistConverter(
+            io.StringIO("source,target\n1,2\n"),
+            "source",
+            "target",
+            u_id_column_dtype=int,
+            v_id_column_dtype=int,
+        )
+
+        self.assertEqual(set(converter.to_graph().nodes), {1, 2})
+
+    def test_extension_dtypes_are_supported(self):
+        converter = EdgelistConverter(
+            io.StringIO("source,target\n1,2\n"),
+            "source",
+            "target",
+            u_id_column_dtype=pd.Int64Dtype(),
+            v_id_column_dtype=pd.Int64Dtype(),
+        )
+
+        self.assertEqual(set(converter.to_graph().nodes), {1, 2})
+
+    def test_boolean_dtypes_parse_strings_consistently(self):
+        dataframe = pd.DataFrame([{"source": "False", "target": "True"}])
+        from_dataframe = EdgelistConverter(
+            dataframe,
+            "source",
+            "target",
+            u_id_column_dtype=bool,
+            v_id_column_dtype=bool,
+        ).to_graph()
+        from_file = EdgelistConverter(
+            io.StringIO("source,target\nFalse,True\n"),
+            "source",
+            "target",
+            u_id_column_dtype=bool,
+            v_id_column_dtype=bool,
+        ).to_graph()
+
+        self.assertEqual(set(from_dataframe.nodes), {False, True})
+        self.assertEqual(set(from_file.nodes), {False, True})
+
+    def test_missing_endpoint_ids_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "cannot contain missing values"):
+            EdgelistConverter(
+                pd.DataFrame([{"source": 1, "target": None}]),
+                "source",
+                "target",
+                u_id_column_dtype=pd.Int64Dtype(),
+                v_id_column_dtype=pd.Int64Dtype(),
+            )
+        with self.assertRaisesRegex(ValueError, "cannot contain missing values"):
+            EdgelistConverter(
+                pd.DataFrame([{"source": "A", "target": None}]),
+                "source",
+                "target",
+            )

--- a/dotmotif/tests/test_dm_flags.py
+++ b/dotmotif/tests/test_dm_flags.py
@@ -83,6 +83,27 @@ class TestDotmotifFlags(unittest.TestCase):
         E = GrandIsoExecutor(graph=G)
         self.assertEqual(len(E.find(dm)), 4)
 
+    def test_from_nx_replaces_parsed_state_and_supports_multigraphs(self):
+        dm = dotmotif.Motif("A -> B\nA.radius = 5\nA === B")
+        graph = nx.MultiDiGraph()
+        graph.add_edge("X", "Y")
+        graph.add_edge("X", "Y")
+
+        dm.from_nx(graph)
+
+        self.assertEqual(dm.to_nx().number_of_edges(), 2)
+        self.assertFalse(dm.list_node_constraints())
+        self.assertFalse(dm.list_edge_constraints())
+        self.assertFalse(dm.list_dynamic_node_constraints())
+        self.assertFalse(dm.list_dynamic_edge_constraints())
+        self.assertFalse(dm.list_automorphisms())
+        self.assertTrue(
+            all(
+                attrs["exists"] and attrs["action"] == "SYN"
+                for _, _, attrs in dm.to_nx().edges(data=True)
+            )
+        )
+
 
 class TestPropagationOfAutomorphicConstraints(unittest.TestCase):
     def test_automorphisms(self):

--- a/dotmotif/tests/test_utils.py
+++ b/dotmotif/tests/test_utils.py
@@ -3,6 +3,8 @@ import networkx as nx
 from ..utils import _deep_merge_constraint_dicts, untype_string, _hashed_dict
 from .. import Motif
 from tempfile import NamedTemporaryFile
+from io import BytesIO
+from pathlib import Path
 
 
 class TestConverter(TestCase):
@@ -37,6 +39,26 @@ class TestSaveLoad(TestCase):
         self.assertEqual(m.enforce_inequality, f.enforce_inequality)
         self.assertEqual(m.pretty_print, f.pretty_print)
         tf.close()
+
+    def test_caller_owned_streams_remain_open(self):
+        motif = Motif("A -> B")
+        stream = BytesIO()
+
+        motif.save(stream)
+        stream.seek(0)
+        loaded = Motif.load(stream)
+
+        self.assertFalse(stream.closed)
+        self.assertTrue(nx.is_isomorphic(motif.to_nx(), loaded.to_nx()))
+
+    def test_pathlike_save_and_load(self):
+        motif = Motif("A -> B")
+        with NamedTemporaryFile() as temporary_file:
+            path = Path(temporary_file.name)
+            motif.save(path)
+            loaded = Motif.load(path)
+
+        self.assertTrue(nx.is_isomorphic(motif.to_nx(), loaded.to_nx()))
 
 
 class TestHashColor(TestCase):


### PR DESCRIPTION
This cleans up a few rough edges around replacing, saving, loading, and ingesting motifs.

- makes `from_nx()` fully replace old parsed state and work with multigraph edges
- keeps caller-owned streams open while still closing files opened from paths
- accepts path-like objects in save/load
- applies endpoint dtypes consistently for file and DataFrame inputs
- rejects missing endpoint IDs instead of turning them into bogus graph nodes